### PR TITLE
Feature/refactor and improve support button email gh issue15

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A dashboard for Tincre [Promo](https://tincre.dev/promo). Use it in conjunction 
         - [`handleRepeatButtonClick`](#handlerepeatbuttonclick)
         - [`handleSubmitSaveButtonClick`](#handlesubmitsavebuttonclick)
         - [`profileSettingsData`](#profilesettingsdata)
+        - [`dashboardOptions`](#dashboardoptions)
       - [Backend](#backend)
       - [Styling](#styling)
   - [Support](#support)
@@ -185,7 +186,22 @@ For example,
   }}
 />
 ```
+##### `dashboardOptions`
 
+Users can customize some behavior within the dashboard, such as the support email domain and the local email part. 
+
+> ℹ️ There are two customizable portions in `team@tincre.dev`, the **local part**, i.e. `team` and the **email domain**, i.e. `tincre.dev`.
+
+For example, 
+
+```jsx
+<PromoDashboard
+  dashboardOptions={{
+    emailDomain: 'tincre.com',
+    emailLocalPart: 'awesome-team',
+  }}
+/>
+```
 #### Backend
 
 🚧 Features and documentation content updates coming soon!

--- a/src/components/Campaign.tsx
+++ b/src/components/Campaign.tsx
@@ -11,22 +11,8 @@ import { CampaignData } from '../lib/types';
 import { CampaignRepeatButton } from './CampaignRepeatButton';
 import { CampaignSupportButton } from './CampaignSupportButton';
 import { CampaignPaymentButton } from './CampaignPaymentButton';
+import { getSupportLink } from '../lib/support';
 
-const supportDomain = 'tincre.dev';
-const getSupportLink = (data: any) =>
-  `mailto:team@${supportDomain}?subject=${
-    data.pid
-  }%20-%20Support%20request%20from%20${supportDomain}&body=Hi!%20I%20am%20reaching%20out%20to%20request%20support%20for%20campaign%20${
-    data.pid
-  }.%0A%0AMy%20issue%3A%0A%0A%0A%0ACampaign%20input%20data%3A%0A%20%20Ad%20Title%3A%20${
-    data?.adTitle || ''
-  }%0A%20%20Target%20link%3A%20${data?.target || ''}%0A%20%20Budget%3A%20${
-    data?.budget || ''
-  }%0A%20%20Ad%20Copy%3A%20${
-    data?.adCopy || ''
-  }%0A%20%20Call%20to%20action%3A%20${
-    data?.callToAction || ''
-  }%0A%20%20Button%20Text%3A%20${data?.buttonText || ''}`;
 const VIDEO_EXTENSIONS = [
   'm3u8',
   'ts',
@@ -144,7 +130,11 @@ export function Campaign({
               alt={adTitle}
             />
           ) : (
-            <video muted controls className="mx-auto h-32 w-full flex-shrink-0 rounded-b-md rounded-t-sm object-cover px-2">
+            <video
+              muted
+              controls
+              className="mx-auto h-32 w-full flex-shrink-0 rounded-b-md rounded-t-sm object-cover px-2"
+            >
               <source src={creativeUrl} type="video/mp4" />
             </video>
           )}

--- a/src/components/Campaign.tsx
+++ b/src/components/Campaign.tsx
@@ -39,6 +39,8 @@ export function Campaign({
   handleCampaignClick,
   handleGeneratePaymentLinkButtonClick,
   id,
+  emailDomain,
+  emailLocalPart,
   children,
 }: {
   data: CampaignData;
@@ -52,6 +54,8 @@ export function Campaign({
     data: CampaignData
   ) => void;
   id?: string;
+  emailDomain?: string;
+  emailLocalPart?: string;
   children?: ReactNode;
 }) {
   const [isActive, setIsActive] = useState<boolean>(data?.isActive || false);
@@ -94,7 +98,7 @@ export function Campaign({
     if (data?.receiptId) {
       setIsPaid(true);
     }
-    setSupportLink(getSupportLink(data));
+    setSupportLink(getSupportLink(data, emailDomain, emailLocalPart));
   }, [data]);
   useEffect(() => {
     setIsActiveClassName(

--- a/src/components/CampaignList.tsx
+++ b/src/components/CampaignList.tsx
@@ -6,13 +6,14 @@
  */
 import { MouseEvent } from 'react';
 import { Campaign } from './Campaign';
-import { CampaignData } from '../lib/types';
+import { CampaignData, DashboardOptions } from '../lib/types';
 
 export function CampaignList({
   data,
   handleRepeatButtonOnClick,
   handleCampaignClick,
   handleGeneratePaymentLinkButtonClick,
+  dashboardOptions,
 }: {
   data: CampaignData[];
   handleRepeatButtonOnClick: (
@@ -24,6 +25,7 @@ export function CampaignList({
     event: MouseEvent<HTMLButtonElement>,
     data: CampaignData
   ) => void;
+  dashboardOptions?: DashboardOptions;
 }) {
   return (
     <ul
@@ -43,6 +45,8 @@ export function CampaignList({
             handleGeneratePaymentLinkButtonClick={
               handleGeneratePaymentLinkButtonClick
             }
+            emailDomain={dashboardOptions?.emailDomain}
+            emailLocalPart={dashboardOptions?.emailLocalPart}
           />
         );
       })}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,6 +17,7 @@ import {
   DownloadableCampaignStats,
   DownloadableCampaignMetadataSample,
   PromoApiCampaignStatsData,
+  DashboardOptions,
 } from './lib/types';
 import { CampaignList } from './components/CampaignList';
 import { DashboardContainer } from './components/DashboardContainer';
@@ -36,6 +37,7 @@ export function PromoDashboard({
   handleRepeatButtonClick,
   handleSettingsSaveButtonClick,
   handleGeneratePaymentLinkButtonClick,
+  dashboardOptions,
 }: {
   campaignsData: CampaignData[];
   campaignDetailData?: CampaignData;
@@ -52,6 +54,7 @@ export function PromoDashboard({
     event: MouseEvent<HTMLButtonElement>,
     campaignData: CampaignData
   ) => void;
+  dashboardOptions?: DashboardOptions;
 }) {
   const [promoData, setPromoData] = useState<CampaignData | undefined>(
     undefined
@@ -77,6 +80,9 @@ export function PromoDashboard({
   );
   const [profileData, setProfileData] = useState<undefined | Settings>(
     profileSettingsData
+  );
+  const [dbOptions, setDbOptions] = useState<undefined | DashboardOptions>(
+    dashboardOptions
   );
   useEffect(() => {
     if (typeof campaignsData !== 'undefined') {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -235,6 +235,7 @@ export function PromoDashboard({
                     ? handleGeneratePaymentLinkButtonClick
                     : handleGeneratePaymentLinkButtonOnClick
                 }
+                dashboardOptions={dbOptions}
               />
             )}
           </>
@@ -280,4 +281,5 @@ export type {
   DownloadableCampaignMetadataSample,
   PromoApiCampaignStatsData,
   CampaignStatsData,
+  DashboardOptions,
 };

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -12,7 +12,6 @@ export function infoToast(message: string, icon?: string) {
   return toast(message, { icon: icon || 'ℹ️' });
 }
 
-
 export function copyToast(message: string, icon?: string) {
   return toast(message, { icon: icon || '📋️' });
 }

--- a/src/lib/support.ts
+++ b/src/lib/support.ts
@@ -1,0 +1,18 @@
+import { CampaignData } from './types';
+
+const supportDomain = 'tincre.dev';
+
+export const getSupportLink = (data: CampaignData) =>
+  `mailto:team@${supportDomain}?subject=${
+    data.pid
+  }%20-%20Support%20request%20from%20${supportDomain}&body=Hi!%20I%20am%20reaching%20out%20to%20request%20support%20for%20campaign%20${
+    data.pid
+  }.%0A%0AMy%20issue%3A%0A%0A%0A%0ACampaign%20input%20data%3A%0A%20%20Ad%20Title%3A%20${
+    data?.adTitle || ''
+  }%0A%20%20Target%20link%3A%20${data?.target || ''}%0A%20%20Budget%3A%20${
+    data?.budget || ''
+  }%0A%20%20Ad%20Copy%3A%20${
+    data?.adCopy || ''
+  }%0A%20%20Call%20to%20action%3A%20${
+    data?.adCallToAction || ''
+  }%0A%20%20Button%20Text%3A%20${data?.buttonText || ''}`;

--- a/src/lib/support.ts
+++ b/src/lib/support.ts
@@ -1,9 +1,17 @@
 import { CampaignData } from './types';
 
-const supportDomain = 'tincre.dev';
+const EMAILDOMAIN = 'tincre.dev';
+const EMAILLOCALPART = 'team';
 
-export const getSupportLink = (data: CampaignData) =>
-  `mailto:team@${supportDomain}?subject=${
+export const getSupportLink = (
+  data: CampaignData,
+  emailDomain?: string,
+  emailLocalPart?: string
+) => {
+  const supportDomain = emailDomain || EMAILDOMAIN;
+  const localPart = emailLocalPart || EMAILLOCALPART;
+
+  return `mailto:${localPart}@${supportDomain}?subject=${
     data.pid
   }%20-%20Support%20request%20from%20${supportDomain}&body=Hi!%20I%20am%20reaching%20out%20to%20request%20support%20for%20campaign%20${
     data.pid
@@ -16,3 +24,4 @@ export const getSupportLink = (data: CampaignData) =>
   }%0A%20%20Call%20to%20action%3A%20${
     data?.adCallToAction || ''
   }%0A%20%20Button%20Text%3A%20${data?.buttonText || ''}`;
+};

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -92,3 +92,8 @@ export interface Settings {
   userName?: string;
   email?: string;
 }
+
+export interface DashboardOptions {
+  emailDomain?: string;
+  emailLocalPart?: string;
+}

--- a/test/components/Campaign.test.tsx
+++ b/test/components/Campaign.test.tsx
@@ -31,6 +31,9 @@ describe('Campaign', () => {
         data={campaignStubData[5]}
         handleCampaignClick={() => null}
         handleRepeatButtonOnClick={() => null}
+        id="test-campaign-id"
+        emailDomain="tincre.com"
+        emailLocalPart="teamage"
       >
         TestChildren
       </Campaign>

--- a/test/index.test.tsx
+++ b/test/index.test.tsx
@@ -80,6 +80,10 @@ describe('PromoDashboard', () => {
         campaignsData={addedReceiptIdsCampaignData}
         handleRepeatButtonClick={handleRepeatButtonOnClick}
         handleSettingsSaveButtonClick={handleSettingsSaveButtonOnClick}
+        dashboardOptions={{
+          emailDomain: 'tincre.com',
+          emailLocalPart: 'test-team',
+        }}
       />
     );
     const repeatButton = screen.getByLabelText(

--- a/test/lib/support.test.ts
+++ b/test/lib/support.test.ts
@@ -1,0 +1,9 @@
+import { getSupportLink } from '../../src/lib/support';
+import { campaignStubData } from '../cms.data';
+
+describe('getSupportLink', () => {
+  it('returns the prepared email support link', () => {
+    const supportLink = getSupportLink(campaignStubData[0]);
+    expect(typeof supportLink).toBe('string');
+  });
+});

--- a/test/lib/support.test.ts
+++ b/test/lib/support.test.ts
@@ -2,8 +2,18 @@ import { getSupportLink } from '../../src/lib/support';
 import { campaignStubData } from '../cms.data';
 
 describe('getSupportLink', () => {
-  it('returns the prepared email support link', () => {
+  it('returns the prepared email support link using defaults', () => {
     const supportLink = getSupportLink(campaignStubData[0]);
     expect(typeof supportLink).toBe('string');
+    expect(supportLink).toContain('team@tincre.dev');
+  });
+  it('returns the prepared email support link using parameters', () => {
+    const supportLink = getSupportLink(
+      campaignStubData[0],
+      'tincre.com',
+      'team'
+    );
+    expect(typeof supportLink).toBe('string');
+    expect(supportLink).toContain('team@tincre.com');
   });
 });


### PR DESCRIPTION
This refactors and cleans up the email support items. Closes #15 by completing:

1. Refactor `getSupport` into `lib/support.ts` utility file, and import
2. `getSupport` gets `emailDomain` and `emailLocalPart` parameters (string types)
3. `getSupport` uses the defaults (static variables) if the parameters are not provided
4. Taking `emailDomain` and `emailLocalPart` parameters.
5. Adding **4** to documentation.