### PR TITLE
:fire: delete unused 'children' prop

### DIFF
--- a/src/components/CampaignDeleteButton.tsx
+++ b/src/components/CampaignDeleteButton.tsx
@@ -18,7 +18,6 @@ export function CampaignDeleteButton({
     event: MouseEvent<HTMLButtonElement>,
     data: CampaignData
   ) => void;
-  children?: ReactNode;
   id?: string;
 }) {
   return (


### PR DESCRIPTION
The `CampaignDeleteButton` component had an errant prop. This merge removes that.