### PR TITLE
Feature/add unit test for campaign delete component

### DIFF
--- a/test/components/CampaignDeleteButton.test.tsx
+++ b/test/components/CampaignDeleteButton.test.tsx
@@ -1,0 +1,55 @@
+import React, { MouseEvent } from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CampaignDeleteButton } from '../../src/components/CampaignDeleteButton';
+import { campaignStubData } from '../cms.data';
+import { CampaignData } from '../../src/lib/types';
+
+describe('CampaignDeleteButton', () => {
+  let testData = campaignStubData[0];
+  it('renders without crashing', () => {
+    testData.receiptId = undefined;
+    render(<CampaignDeleteButton data={testData} />);
+    const button = screen.getByLabelText(/campaign-delete/i);
+    fireEvent.click(button);
+    expect(button).toBeDefined();
+  });
+  it('renders with children without crashing', () => {
+    testData.receiptId = '';
+    render(
+      <CampaignDeleteButton
+        data={campaignStubData[0]}
+        id="test-id-delete-button"
+      />
+    );
+    const button = screen.getByLabelText(/campaign-delete/i);
+    fireEvent.click(button);
+    expect(button).toBeDefined();
+  });
+  it('renders with handleDeleteButtonOnClick without crashing', () => {
+    let testLocalData: CampaignData | undefined = undefined;
+    let testEvent: MouseEvent<HTMLButtonElement> | undefined = undefined;
+    let testFlag: boolean = false;
+    testData.receiptId = undefined;
+    const handleDeleteButtonOnClick = (
+      event: MouseEvent<HTMLButtonElement>,
+      data: CampaignData
+    ) => {
+      testFlag = true;
+      testLocalData = data;
+      testEvent = event;
+    };
+    render(
+      <CampaignDeleteButton
+        data={campaignStubData[0]}
+        handleDeleteButtonOnClick={handleDeleteButtonOnClick}
+        id="test-id-delete-button"
+      />
+    );
+    const button = screen.getByLabelText(/campaign-delete/i);
+    fireEvent.click(button);
+    expect(button).toBeDefined();
+    expect(testFlag).toBeTruthy();
+    expect(testEvent).toBeDefined();
+    expect(testLocalData).toMatchObject(testData);
+  });
+});

--- a/test/components/CampaignPaymentButton.test.tsx
+++ b/test/components/CampaignPaymentButton.test.tsx
@@ -4,7 +4,7 @@ import { CampaignPaymentButton } from '../../src/components/CampaignPaymentButto
 import { campaignStubData } from '../cms.data';
 import { CampaignData } from '../../src/lib/types';
 
-describe('CampaignRepeatButton', () => {
+describe('CampaignPaymentButton', () => {
   let testData = campaignStubData[0];
   it('renders without crashing', () => {
     testData.receiptId = undefined;
@@ -24,7 +24,7 @@ describe('CampaignRepeatButton', () => {
     fireEvent.click(button);
     expect(button).toBeDefined();
   });
-  it('renders with handleRepeatButtonOnClick without crashing', () => {
+  it('renders with handleGeneratePaymentLinkButtonClick without crashing', () => {
     let testLocalData: CampaignData | undefined = undefined;
     let testEvent: MouseEvent<HTMLButtonElement> | undefined = undefined;
     let testFlag: boolean = false;


### PR DESCRIPTION
This improves tests by adding a unit test for the `CampaignDeleteButton` component and fixing the naming for `CampaignPaymentButton` component test from `Repeat` to `Payments`. 