### PR TITLE
Feature/expose campaign button handlers gl issue32

### DIFF
--- a/src/components/Campaign.tsx
+++ b/src/components/Campaign.tsx
@@ -50,7 +50,10 @@ export function Campaign({
     event: MouseEvent<HTMLButtonElement>,
     data: CampaignData
   ) => void;
-  handleCampaignClick: Function;
+  handleCampaignClick: (
+    event: MouseEvent<HTMLButtonElement>,
+    data: CampaignData
+  ) => void;
   handleGeneratePaymentLinkButtonClick?: (
     event: MouseEvent<HTMLButtonElement>,
     data: CampaignData
@@ -135,7 +138,7 @@ export function Campaign({
         />
       )}
       <button
-        onClick={() => handleCampaignClick(data)}
+        onClick={(event) => handleCampaignClick(event, data)}
         aria-label={`campaign-${data?.pid || 'default'}-button`}
       >
         <div className="relative flex flex-1 flex-col px-2 pt-10 pb-6 group-hover:rounded-tr-md group-hover:rounded-tl-sm group-hover:bg-slate-900">

--- a/src/components/CampaignDetail.tsx
+++ b/src/components/CampaignDetail.tsx
@@ -57,7 +57,7 @@ export function CampaignDetail({
         <Button
           className="mx-2 mt-2 inline"
           onClick={handleCampaignDetailBackOnClick}
-          aria-label={`campaign-detail-back-${data?.pid || ''}`}
+          aria-label="promo-dashboard-campaign-detail-back-button"
           id="promo-dashboard-campaign-detail-back-button"
         >
           Back

--- a/src/components/CampaignDetail.tsx
+++ b/src/components/CampaignDetail.tsx
@@ -86,7 +86,6 @@ export function CampaignDetail({
         handleStatsHighlightClick={handleStatsHighlightClick}
         statsHighlightMetricsName={statsHighlightMetricName || 'Spend'}
       />
-      {/*@ts-ignore*/}
       <Button
         className="mx-2 mt-4 mb-2 sm:hidden"
         onClick={handleCampaignDetailBackOnClick}

--- a/src/components/CampaignList.tsx
+++ b/src/components/CampaignList.tsx
@@ -22,7 +22,10 @@ export function CampaignList({
     event: MouseEvent<HTMLButtonElement>,
     data: CampaignData
   ) => void;
-  handleCampaignClick: Function;
+  handleCampaignClick: (
+    event: MouseEvent<HTMLButtonElement>,
+    data: CampaignData
+  ) => void;
   handleGeneratePaymentLinkButtonClick: (
     event: MouseEvent<HTMLButtonElement>,
     data: CampaignData

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -38,6 +38,7 @@ export function PromoDashboard({
   handleSettingsSaveButtonClick,
   handleGeneratePaymentLinkButtonClick,
   handleDeleteButtonClick,
+  handleCampaignDetailBackClick,
   dashboardOptions,
 }: {
   campaignsData: CampaignData[];
@@ -58,6 +59,9 @@ export function PromoDashboard({
   handleDeleteButtonClick?: (
     event: MouseEvent<HTMLButtonElement>,
     campaignData: CampaignData
+  ) => void;
+  handleCampaignDetailBackClick?: (
+    event: MouseEvent<HTMLButtonElement>
   ) => void;
   dashboardOptions?: DashboardOptions;
 }) {
@@ -197,7 +201,12 @@ export function PromoDashboard({
     }
   };
 
-  const handleCampaignDetailBackOnClick = () => {
+  const handleCampaignDetailBackOnClick = (
+    event: MouseEvent<HTMLButtonElement>
+  ) => {
+    if (typeof handleCampaignDetailBackClick !== 'undefined') {
+      handleCampaignDetailBackClick(event);
+    }
     setIsCampaignClicked(false);
     setClickedStatsClassName(options.defaultStatName); // default
   };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -38,6 +38,7 @@ export function PromoDashboard({
   handleSettingsSaveButtonClick,
   handleGeneratePaymentLinkButtonClick,
   handleDeleteButtonClick,
+  handleCampaignClick,
   handleCampaignDetailBackClick,
   dashboardOptions,
 }: {
@@ -59,6 +60,10 @@ export function PromoDashboard({
   handleDeleteButtonClick?: (
     event: MouseEvent<HTMLButtonElement>,
     campaignData: CampaignData
+  ) => void;
+  handleCampaignClick?: (
+    event: MouseEvent<HTMLButtonElement>,
+    data: CampaignData
   ) => void;
   handleCampaignDetailBackClick?: (
     event: MouseEvent<HTMLButtonElement>
@@ -189,7 +194,10 @@ export function PromoDashboard({
       setIsPaymentButtonClicked(!isPaymentButtonClicked);
     }
   };
-  const handleCampaignClick = (data: CampaignData) => {
+  const handleCampaignOnClick = (event: MouseEvent<HTMLButtonElement>, data: CampaignData) => {
+    if (typeof handleCampaignClick !== 'undefined') {
+      handleCampaignClick(event, data);
+    }
     setPromoData(data);
     setIsCampaignClicked(true);
     if (data?.data?.length) {
@@ -285,7 +293,7 @@ export function PromoDashboard({
                     ? handleRepeatButtonClick
                     : handleRepeatButtonOnClick
                 }
-                handleCampaignClick={handleCampaignClick}
+                handleCampaignClick={handleCampaignOnClick}
                 handleGeneratePaymentLinkButtonClick={
                   typeof handleGeneratePaymentLinkButtonClick !== 'undefined'
                     ? handleGeneratePaymentLinkButtonClick

--- a/test/components/Campaign.test.tsx
+++ b/test/components/Campaign.test.tsx
@@ -26,6 +26,7 @@ describe('Campaign', () => {
   });
   it('renders full data inactive without crashing', () => {
     expect(campaignStubData[5].isActive).toBeFalsy();
+
     render(
       <Campaign
         data={campaignStubData[5]}
@@ -46,5 +47,33 @@ describe('Campaign', () => {
     expect(testChildren).toBeDefined();
     fireEvent.click(campaign);
     expect(campaign).toBeDefined();
+  });
+  it('renders campaignClick without crashing', () => {
+    expect(campaignStubData[5].isActive).toBeFalsy();
+    let isCampaignClicked = false;
+    const testCampaignClick = (event: any, data: any) => {
+      isCampaignClicked = true;
+    };
+    render(
+      <Campaign
+        data={campaignStubData[5]}
+        handleCampaignClick={testCampaignClick}
+        handleRepeatButtonOnClick={() => null}
+        id="test-campaign-id"
+        emailDomain="tincre.com"
+        emailLocalPart="teamage"
+      >
+        TestChildren
+      </Campaign>
+    );
+    let campaign = screen.getByLabelText(
+      `campaign-${campaignStubData[5].pid}-button`
+    );
+
+    const testChildren = screen.getByText(/TestChildren/i);
+    expect(testChildren).toBeDefined();
+    fireEvent.click(campaign);
+    expect(campaign).toBeDefined();
+    expect(isCampaignClicked).toBeTruthy();
   });
 });

--- a/test/index.test.tsx
+++ b/test/index.test.tsx
@@ -133,6 +133,7 @@ describe('PromoDashboard', () => {
     const setPromoData = (data: any) => data;
     const isRepeatButtonClicked = false;
     const setIsRepeatButtonClicked = (tf: boolean) => tf;
+    let isCampaignClicked = false;
     const handleSettingsSaveButtonOnClick = (
       event: MouseEvent<HTMLButtonElement>,
       data: Settings
@@ -140,11 +141,20 @@ describe('PromoDashboard', () => {
       testEvent = event;
       testData = data;
     };
+    const handleCampaignClick = (
+      event: MouseEvent<HTMLButtonElement>,
+      data: Settings
+    ) => {
+      testEvent = event;
+      testData = data;
+      isCampaignClicked = true;
+    };
 
     render(
       <PromoDashboard
         campaignsData={campaignStubData}
         handleSettingsSaveButtonClick={handleSettingsSaveButtonOnClick}
+        handleCampaignClick={handleCampaignClick}
         profileSettingsData={{
           userName: 'testUserName',
           fullName: 'Test McTesterson',
@@ -152,6 +162,10 @@ describe('PromoDashboard', () => {
         }}
       />
     );
+    let campaign = screen.getByLabelText(
+      `campaign-${campaignStubData[5].pid}-button`
+    );
+
     const imageInput = screen.getByRole('textbox', { name: 'Avatar' });
     expect(imageInput).toBeDefined();
     // @ts-ignore
@@ -166,5 +180,8 @@ describe('PromoDashboard', () => {
     expect(fullNameInput).toBeDefined();
     // @ts-ignore
     expect(fullNameInput.value).toBe('Test McTesterson');
+    fireEvent.click(campaign);
+    expect(campaign).toBeDefined();
+    expect(isCampaignClicked).toBeTruthy();
   });
 });

--- a/test/index.test.tsx
+++ b/test/index.test.tsx
@@ -134,6 +134,7 @@ describe('PromoDashboard', () => {
     const isRepeatButtonClicked = false;
     const setIsRepeatButtonClicked = (tf: boolean) => tf;
     let isCampaignClicked = false;
+    let isCampaignDetailBackClicked = false;
     const handleSettingsSaveButtonOnClick = (
       event: MouseEvent<HTMLButtonElement>,
       data: Settings
@@ -150,11 +151,19 @@ describe('PromoDashboard', () => {
       isCampaignClicked = true;
     };
 
+    const handleCampaignDetailBackClick = (
+      event: MouseEvent<HTMLButtonElement>
+    ) => {
+      testEvent = event;
+      isCampaignDetailBackClicked = true;
+    };
+
     render(
       <PromoDashboard
         campaignsData={campaignStubData}
         handleSettingsSaveButtonClick={handleSettingsSaveButtonOnClick}
         handleCampaignClick={handleCampaignClick}
+        handleCampaignDetailBackClick={handleCampaignDetailBackClick}
         profileSettingsData={{
           userName: 'testUserName',
           fullName: 'Test McTesterson',
@@ -165,7 +174,6 @@ describe('PromoDashboard', () => {
     let campaign = screen.getByLabelText(
       `campaign-${campaignStubData[5].pid}-button`
     );
-
     const imageInput = screen.getByRole('textbox', { name: 'Avatar' });
     expect(imageInput).toBeDefined();
     // @ts-ignore
@@ -183,5 +191,12 @@ describe('PromoDashboard', () => {
     fireEvent.click(campaign);
     expect(campaign).toBeDefined();
     expect(isCampaignClicked).toBeTruthy();
+
+    let campaignDetailBackButton = screen.getAllByRole('button', {
+      name: 'Back',
+    })[0];
+    fireEvent.click(campaignDetailBackButton);
+    expect(campaignDetailBackButton).toBeDefined();
+    expect(isCampaignDetailBackClicked).toBeTruthy();
   });
 });


### PR DESCRIPTION
This exposes handleCampaignDetailBackClick and handleCampaignClick to close [#32](https://gitlab.com/tincre/promo-dashboard/-/issues/32).

It also includes basic tests for this customization. 

This now allows callers to have a custom function called for each page of the dashboard.