### PR TITLE
Feature/fix data sorting order issue gl issue30

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -194,7 +194,10 @@ export function PromoDashboard({
       setIsPaymentButtonClicked(!isPaymentButtonClicked);
     }
   };
-  const handleCampaignOnClick = (event: MouseEvent<HTMLButtonElement>, data: CampaignData) => {
+  const handleCampaignOnClick = (
+    event: MouseEvent<HTMLButtonElement>,
+    data: CampaignData
+  ) => {
     if (typeof handleCampaignClick !== 'undefined') {
       handleCampaignClick(event, data);
     }

--- a/src/lib/coerce.ts
+++ b/src/lib/coerce.ts
@@ -60,7 +60,8 @@ export function coercePromoApiDataForChartJs(
 ) {
   let chartJsData = generateEmptyPromoApiDataForChartJs();
   if (typeof data !== 'undefined') {
-    data.forEach((pckg) => {
+    for (let index = data.length - 1; index >= 0; index--) {
+      let pckg = data[index];
       chartJsData.updatedTime.push(pckg?.updated_time?.slice(0, 10) || null);
       chartJsData.spend.push(
         typeof pckg?.spend !== 'undefined' ? pckg.spend : null
@@ -78,7 +79,7 @@ export function coercePromoApiDataForChartJs(
       chartJsData.clicks.push(
         typeof pckg?.clicks !== 'undefined' ? pckg.clicks : null
       );
-    });
+    }
   }
   return chartJsData;
 }

--- a/test/lib/coerce.test.ts
+++ b/test/lib/coerce.test.ts
@@ -10,7 +10,9 @@ describe('coercePromoApiDataForChartJs', () => {
     const coerced = coercePromoApiDataForChartJs(
       testPromoApiTimeseriesData.data.totals
     );
-    expect(coerced.updatedTime[0]).toBe('2023-02-19');
+    expect(coerced.updatedTime[coerced.updatedTime.length - 1]).toBe(
+      '2023-02-19'
+    );
   });
 });
 


### PR DESCRIPTION
This closes [#30](https://gitlab.com/tincre/promo-dashboard/-/issues/30) by adding a proper loop from the end rather than the front of the initial campaign data array when sorting for ChartJS. 