### PR TITLE
:bug: reverse index for all campaigns function

### DIFF
--- a/src/lib/coerce.ts
+++ b/src/lib/coerce.ts
@@ -282,6 +282,7 @@ export function modifyMultiCampaignsDataForDownload(
   });
   return modifiedData;
 }
+
 export function modifySingleCampaignDataForDownload(
   campaignData: CampaignData
 ) {

--- a/src/lib/coerce.ts
+++ b/src/lib/coerce.ts
@@ -254,7 +254,8 @@ export function modifyMultiCampaignsDataForDownload(
   campaignsData.forEach((pckg) => {
     let data = modifySingleCampaignDataForDownload(pckg);
     if (typeof data !== 'undefined') {
-      let { updatedTime, spend, views, clicks, cpc, cpm, ctr, cpv } = data[0];
+      let { updatedTime, spend, views, clicks, cpc, cpm, ctr, cpv } =
+        data[data.length - 1];
       let result = {
         pid: pckg?.pid || '',
         updatedTime: updatedTime,
@@ -286,56 +287,25 @@ export function modifySingleCampaignDataForDownload(
 ) {
   let data: CampaignStatsData[] | undefined =
     campaignData?.data || campaignData?.stats;
-  let pid: string[] = [];
+  let pid: string = campaignData.pid || '';
   let chartJsData = generateEmptyPromoApiDataForChartJs();
   let modifiedData: DownloadableCampaignStatsSample[] = [];
   if (typeof data !== 'undefined') {
     data.forEach((pckg: CampaignStatsData) => {
       const chartData = pckg?.chartData;
       chartJsData.updatedTime = chartData.labels;
-      pid.push(campaignData.pid || '');
-      if (pckg.name === 'Spend') {
-        chartJsData.spend = chartData.data;
-        return;
-      }
-      if (pckg.name === 'Reach') {
-        chartJsData.reach = chartData.data;
-        return;
-      }
-      if (pckg.name === 'Views') {
-        chartJsData.views = chartData.data;
-        return;
-      }
-      if (pckg.name === 'Clicks') {
-        chartJsData.clicks = chartData.data;
-        return;
-      }
-      if (pckg.name === 'CPC') {
-        chartJsData.cpc = chartData.data;
-        return;
-      }
-      if (pckg.name === 'CPM') {
-        chartJsData.cpm = chartData.data;
-        return;
-      }
-      if (pckg.name === 'CTR') {
-        chartJsData.ctr = chartData.data;
-        return;
-      }
-      if (pckg.name === 'CPV') {
-        chartJsData.cpv = chartData.data;
-        return;
-      }
+      // @ts-ignore
+      chartJsData[pckg.name.toLowerCase()] = chartData.data;
     });
     let modifiedObject = {
       ...chartJsData,
       pid,
     };
-
-    pid.forEach((pid, index) => {
-      modifiedData.push({
-        pid: pid,
-        updatedTime: modifiedObject.updatedTime[index] || '',
+    let timestamps = modifiedObject.updatedTime;
+    timestamps.forEach((timestamp, index) => {
+      const mdtmp = {
+        pid: pid || '',
+        updatedTime: timestamp || '',
         spend: modifiedObject.spend[index],
         views: modifiedObject?.views[index],
         clicks: modifiedObject?.clicks[index],
@@ -343,7 +313,8 @@ export function modifySingleCampaignDataForDownload(
         cpm: modifiedObject?.cpm[index],
         ctr: modifiedObject?.ctr[index],
         cpv: modifiedObject?.cpv[index],
-      });
+      };
+      modifiedData.push(mdtmp);
     });
     return modifiedData;
   }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -56,7 +56,7 @@ export interface DownloadableCampaignStats {
 }
 export interface CampaignStatsData {
   id: number;
-  name: string;
+  name: 'Spend' | 'Clicks' | 'Views' | 'CPM' | 'CTR' | 'CPC' | 'CPV';
   stat: string;
   change: string | number;
   changeType: string;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -56,7 +56,7 @@ export interface DownloadableCampaignStats {
 }
 export interface CampaignStatsData {
   id: number;
-  name: 'Spend' | 'Clicks' | 'Views' | 'CPM' | 'CTR' | 'CPC' | 'CPV';
+  name: 'Spend' | 'Clicks' | 'Views' | 'CPM' | 'CTR' | 'CPC' | 'CPV' | string;
   stat: string;
   change: string | number;
   changeType: string;


### PR DESCRIPTION
This fixes download single and all campaigns data issues. Prior to this we were only sending back 6-7 days of data, depending on how many metrics were being tracked. 

This was due to indexing an array on the looped data updating functions in `src/lib/coerce.ts` for each of the metrics. 

This merge indexes on the length of `updatedTime` array for each campaign.