### PR TITLE
:arrow_up: upgrade promo dashboard to 0.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,5 +82,8 @@
     "tslib": "^2.4.0",
     "typescript": "^4.8.4",
     "yup": "^0.32.11"
+  },
+  "dependencies": {
+    "@tincre/promo-dashboard": "^0.10.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1583,6 +1583,11 @@
     "@testing-library/dom" "^8.5.0"
     "@types/react-dom" "^18.0.0"
 
+"@tincre/promo-dashboard@^0.10.0":
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/@tincre/promo-dashboard/-/promo-dashboard-0.10.0.tgz#64b882d8de1d46327675da39ac75d5e09ebf1db7"
+  integrity sha512-djw/ca1bRdVn9DTwGm9ACq8kgdqOVN9SXFC39DxkMKhlXZPTO+jaPh0MdhdAj5zeyCxGUppkJxnPDeG+9JaEsw==
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"


### PR DESCRIPTION
This is a simple upgrade of development example app promo-dashboard to 0.10.0.