### PR TITLE
:bug: add condition to check for NaN dates

### DIFF
--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -44,6 +44,7 @@ export function generateStringDateRanges(
         return date.toISOString().slice(0, 10);
       }
     }
+    return new Date().toISOString().slice(0, 10);
   });
 }
 export function generateDates(length: number, endDate?: Date) {

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -38,7 +38,13 @@ export function generateStringDateRanges(
           includeEndDate
         )
       : generateDateRange(new Date(startDate), undefined, includeEndDate);
-  return tmpDates.map((date) => date.toISOString().slice(0, 10));
+  return tmpDates.map((date) => {
+    if (Object.prototype.toString.call(date) === '[object Date]') {
+      if (!Number.isNaN(date.valueOf())) {
+        return date.toISOString().slice(0, 10);
+      }
+    }
+  });
 }
 export function generateDates(length: number, endDate?: Date) {
   const dates: string[] = [];


### PR DESCRIPTION
This fixes the "invalid date" error users see in firefox. Some undefined dates were making it through the date builder.

This merge adds a check for the conditional `Number.isNaN(new Date('undefined').valueOf())` before passing the date back inside of `generateDateStringRanges`. 