### PR TITLE
Feature/add default campaign show and fix tests

### DIFF
--- a/src/components/Campaign.tsx
+++ b/src/components/Campaign.tsx
@@ -46,6 +46,7 @@ export function Campaign({
   id,
   emailDomain,
   emailLocalPart,
+  shouldShowCampaign = false,
   children,
 }: {
   data: CampaignData | CampaignDummyData;
@@ -68,6 +69,7 @@ export function Campaign({
   id?: string;
   emailDomain?: string;
   emailLocalPart?: string;
+  shouldShowCampaign?: boolean;
   children?: ReactNode;
 }) {
   const [isActive, setIsActive] = useState<boolean>(data?.isActive || false);
@@ -85,7 +87,8 @@ export function Campaign({
   const [dollarAmount, setDollarAmount] = useState<string>('');
   const [supportLink, setSupportLink] = useState<string>('');
   const [isVideo, setIsVideo] = useState<boolean | undefined>(undefined);
-  const [shouldShowCampaign, setShouldShowCampaign] = useState<boolean>(false);
+  const [shouldShowCampaignInternal, setShouldShowCampaignInternal] =
+    useState<boolean>(shouldShowCampaign || false);
   useEffect(() => {
     if (data?.isActive && typeof data?.isActive) {
       setIsActive(data?.isActive);
@@ -128,7 +131,7 @@ export function Campaign({
   return (
     <InView
       onChange={(inView, entry) => {
-        if (inView) setShouldShowCampaign(true);
+        if (inView) setShouldShowCampaignInternal(true);
       }}
       triggerOnce={true}
       as="li"
@@ -137,7 +140,7 @@ export function Campaign({
       aria-label={`campaign-${data.pid}`}
       className={isActiveClassName}
     >
-      {shouldShowCampaign ? (
+      {shouldShowCampaignInternal ? (
         <>
           <button
             onClick={(event) => handleCampaignClick(event, data)}

--- a/src/components/CampaignList.tsx
+++ b/src/components/CampaignList.tsx
@@ -51,6 +51,7 @@ export function CampaignList({
         const pid = `${campaignData.pid}`;
         if (!deletedCampaigns.includes(pid)) {
           const key = `${index}-${pid}`;
+          const shouldShowCampaign = index < 4 ? true : false;
           return (
             <Campaign
               key={key}
@@ -64,6 +65,7 @@ export function CampaignList({
               handleDeleteButtonOnClick={handleDeleteButtonOnClick}
               emailDomain={dashboardOptions?.emailDomain}
               emailLocalPart={dashboardOptions?.emailLocalPart}
+              shouldShowCampaign={shouldShowCampaign}
             />
           );
         }

--- a/test/components/Campaign.test.tsx
+++ b/test/components/Campaign.test.tsx
@@ -1,17 +1,29 @@
 import React from 'react';
+import {
+  mockAllIsIntersecting,
+  setupIntersectionMocking,
+  resetIntersectionMocking,
+} from 'react-intersection-observer/test-utils';
 import { screen, render, fireEvent } from '@testing-library/react';
 import { Campaign } from '../../src/components/Campaign';
 import { campaignStubData } from '../cms.data';
 
+beforeEach(() => {
+  setupIntersectionMocking(jest.fn);
+});
+afterEach(() => {
+  resetIntersectionMocking();
+});
 describe('Campaign', () => {
   it('renders full data active without crashing', () => {
+    mockAllIsIntersecting(true);
     expect(campaignStubData[0].isActive).toBeTruthy();
-
     render(
       <Campaign
         data={campaignStubData[0]}
         handleCampaignClick={() => null}
         handleRepeatButtonOnClick={() => null}
+        shouldShowCampaign={true}
       >
         TestChildren
       </Campaign>
@@ -35,6 +47,7 @@ describe('Campaign', () => {
         id="test-campaign-id"
         emailDomain="tincre.com"
         emailLocalPart="teamage"
+        shouldShowCampaign={true}
       >
         TestChildren
       </Campaign>
@@ -62,6 +75,7 @@ describe('Campaign', () => {
         id="test-campaign-id"
         emailDomain="tincre.com"
         emailLocalPart="teamage"
+        shouldShowCampaign={true}
       >
         TestChildren
       </Campaign>

--- a/test/components/CampaignList.test.tsx
+++ b/test/components/CampaignList.test.tsx
@@ -2,9 +2,27 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { CampaignList } from '../../src/components/CampaignList';
 import { campaignStubData } from '../cms.data';
+import {
+  mockAllIsIntersecting,
+  setupIntersectionMocking,
+  resetIntersectionMocking,
+} from 'react-intersection-observer/test-utils';
+
+window.scrollTo = jest.fn();
+
+beforeEach(() => {
+  setupIntersectionMocking(jest.fn);
+});
+afterEach(() => {
+  resetIntersectionMocking();
+});
+afterAll(() => {
+  jest.clearAllMocks();
+});
 
 describe('CampaignList', () => {
   it('renders full data without crashing', () => {
+    mockAllIsIntersecting(true); 
     render(
       <CampaignList
         data={campaignStubData}

--- a/test/index.test.tsx
+++ b/test/index.test.tsx
@@ -3,14 +3,34 @@ import { screen, render, fireEvent } from '@testing-library/react';
 import { PromoDashboard } from '../src/index';
 import { campaignStubData } from './cms.data';
 import { CampaignData, CampaignDummyData, Settings } from '../src/lib/types';
+import {
+  mockAllIsIntersecting,
+  setupIntersectionMocking,
+  resetIntersectionMocking,
+} from 'react-intersection-observer/test-utils';
 
+window.scrollTo = jest.fn();
+
+beforeEach(() => {
+  setupIntersectionMocking(jest.fn);
+});
+afterEach(() => {
+  resetIntersectionMocking();
+});
+afterAll(() => {
+  jest.clearAllMocks();
+});
 global.ResizeObserver = require('resize-observer-polyfill');
 
 describe('PromoDashboard', () => {
   it('renders empty array prop without crashing', () => {
+    mockAllIsIntersecting(true);
+
     render(<PromoDashboard campaignsData={[]} />);
   });
   it('renders full data without crashing', () => {
+    mockAllIsIntersecting(true);
+
     render(
       <PromoDashboard
         campaignsData={campaignStubData}
@@ -27,6 +47,8 @@ describe('PromoDashboard', () => {
     fireEvent.click(dashboardButton);
   });
   it('renders full data without crashing and isLoading', () => {
+    mockAllIsIntersecting(true);
+
     render(
       <PromoDashboard
         campaignsData={campaignStubData}
@@ -44,6 +66,8 @@ describe('PromoDashboard', () => {
   });
 
   it('renders the dashboard payment button without crashing', () => {
+    mockAllIsIntersecting(true);
+
     let isDeleteButtonClicked = false;
     const handleDeleteButtonClick = (
       event: React.MouseEvent<HTMLButtonElement>,
@@ -76,6 +100,8 @@ describe('PromoDashboard', () => {
     expect(isDeleteButtonClicked).toBeTruthy();
   });
   it('renders full data without crashing', () => {
+    mockAllIsIntersecting(true);
+
     let testEvent: MouseEvent<HTMLButtonElement> | undefined = undefined;
     let testData: Settings | undefined = undefined;
     const setPromoData = (data: any) => data;
@@ -147,6 +173,8 @@ describe('PromoDashboard', () => {
   });
 
   it('renders full data and settings data without crashing', () => {
+    mockAllIsIntersecting(true);
+
     let testEvent: MouseEvent<HTMLButtonElement> | undefined = undefined;
     let testData: Settings | undefined = undefined;
     const setPromoData = (data: any) => data;
@@ -191,7 +219,7 @@ describe('PromoDashboard', () => {
       />
     );
     let campaign = screen.getByLabelText(
-      `campaign-${campaignStubData[5].pid}-button`
+      `campaign-${campaignStubData[2].pid}-button`
     );
     const imageInput = screen.getByRole('textbox', { name: 'Avatar' });
     expect(imageInput).toBeDefined();


### PR DESCRIPTION
The addition of version 0.11.6 broke our unit test suite due to default campaigns not showing until scrolled to. This is not "fixable" using JSDOM, as it [doesn't support layout](https://github.com/testing-library/react-testing-library/issues/671#issuecomment-629380220).

To properly test in CICD the code that leverages intersection-observer we'll need to add browser-based integration tests, like Cypress or Puppeteer, out of scope for this merge.

I added the first four campaign rendering to default to show and our unit tests test on those, now. Anything after will need the user to scroll to the campaign (which we'll test in an upcoming integration test issue).