### PR TITLE
Feature/add campaign table

### DIFF
--- a/example/nextjs/pages/index.tsx
+++ b/example/nextjs/pages/index.tsx
@@ -1,8 +1,8 @@
 import { useState, useEffect, MouseEvent } from 'react';
 import type { NextPage } from 'next';
 import Head from 'next/head';
-//import { PromoDashboard } from '@tincre/promo-dashboard';
-import { PromoDashboard } from '../../../dist';
+import { PromoDashboard } from '@tincre/promo-dashboard';
+//import { PromoDashboard } from '../../../dist';
 //import { campaignStubData } from '../cms.data';
 import { campaignStubData } from '../test.data';
 import { useTour } from '@reactour/tour';

--- a/example/nextjs/pages/index.tsx
+++ b/example/nextjs/pages/index.tsx
@@ -1,10 +1,10 @@
 import { useState, useEffect, MouseEvent } from 'react';
 import type { NextPage } from 'next';
 import Head from 'next/head';
-import { PromoDashboard } from '@tincre/promo-dashboard';
-//import { PromoDashboard } from '../../../dist';
-import { campaignStubData } from '../cms.data';
-//import { campaignStubData } from '../test.data';
+//import { PromoDashboard } from '@tincre/promo-dashboard';
+import { PromoDashboard } from '../../../dist';
+//import { campaignStubData } from '../cms.data';
+import { campaignStubData } from '../test.data';
 import { useTour } from '@reactour/tour';
 
 const Home: NextPage = () => {
@@ -17,7 +17,6 @@ const Home: NextPage = () => {
     data: any
   ) => {
     setIsRepeatButtonClicked(true);
-    console.debug(`handleRepeatButtonClick::type ${event.type}`);
     console.debug(
       `handleRepeatButtonClick::Repeat button was clicked, updating state.`
     );

--- a/src/components/CampaignsSummaryStats.tsx
+++ b/src/components/CampaignsSummaryStats.tsx
@@ -5,13 +5,18 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 import { MouseEventHandler, MouseEvent, useState, useEffect } from 'react';
-import { CampaignStatsData, CampaignData } from '../lib/types';
+import {
+  CampaignStatsData,
+  CampaignData,
+  CampaignDummyData,
+} from '../lib/types';
 import { CampaignsStatsHighlights } from './CampaignsStatsHighlights';
 import { CampaignsChart } from './CampaignsChart';
 import { merge } from '../lib/merge';
 import { options } from '../lib/options';
 import { disectChartData } from '../lib/disectChartData';
 import { CampaignsTable } from './CampaignsTable';
+
 export function CampaignsSummaryStats({
   data,
   statsHighlightTimeseries,
@@ -22,7 +27,7 @@ export function CampaignsSummaryStats({
   data?: CampaignStatsData[];
   statsHighlightTimeseries?: CampaignStatsData;
   statsHighlightMetricName?: string;
-  campaignData: CampaignData[];
+  campaignData: CampaignData[] | CampaignDummyData[];
   handleCampaignDetailBackOnClick: MouseEventHandler<HTMLButtonElement>;
   handleStatsHighlightClick?: Function /* TODO type this */;
 }) {

--- a/src/components/CampaignsSummaryStats.tsx
+++ b/src/components/CampaignsSummaryStats.tsx
@@ -5,22 +5,24 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 import { MouseEventHandler, MouseEvent, useState, useEffect } from 'react';
-import { CampaignStatsData } from '../lib/types';
+import { CampaignStatsData, CampaignData } from '../lib/types';
 import { CampaignsStatsHighlights } from './CampaignsStatsHighlights';
 import { CampaignsChart } from './CampaignsChart';
 import { merge } from '../lib/merge';
 import { options } from '../lib/options';
 import { disectChartData } from '../lib/disectChartData';
-
+import { CampaignsTable } from './CampaignsTable';
 export function CampaignsSummaryStats({
   data,
   statsHighlightTimeseries,
   statsHighlightMetricName,
+  campaignData,
   handleStatsHighlightClick,
 }: {
   data?: CampaignStatsData[];
   statsHighlightTimeseries?: CampaignStatsData;
   statsHighlightMetricName?: string;
+  campaignData: CampaignData[];
   handleCampaignDetailBackOnClick: MouseEventHandler<HTMLButtonElement>;
   handleStatsHighlightClick?: Function /* TODO type this */;
 }) {
@@ -79,6 +81,7 @@ export function CampaignsSummaryStats({
             handleStatsHighlightClick={handleStatsHighlightClick}
             statsHighlightMetricsName={statsHighlightMetricName || 'Spend'}
           />
+          <CampaignsTable data={campaignData} />
         </>
       )}
     </>

--- a/src/components/CampaignsSummaryStats.tsx
+++ b/src/components/CampaignsSummaryStats.tsx
@@ -23,6 +23,7 @@ export function CampaignsSummaryStats({
   statsHighlightMetricName,
   campaignData,
   handleStatsHighlightClick,
+  handleCampaignClick,
 }: {
   data?: CampaignStatsData[];
   statsHighlightTimeseries?: CampaignStatsData;
@@ -30,6 +31,10 @@ export function CampaignsSummaryStats({
   campaignData: CampaignData[] | CampaignDummyData[];
   handleCampaignDetailBackOnClick: MouseEventHandler<HTMLButtonElement>;
   handleStatsHighlightClick?: Function /* TODO type this */;
+  handleCampaignClick: (
+    event: MouseEvent<HTMLButtonElement>,
+    data: CampaignData | CampaignDummyData
+  ) => void;
 }) {
   const [selectedChartButton, setSelectedChartButton] = useState(
     options.timePeriods[0]
@@ -86,7 +91,10 @@ export function CampaignsSummaryStats({
             handleStatsHighlightClick={handleStatsHighlightClick}
             statsHighlightMetricsName={statsHighlightMetricName || 'Spend'}
           />
-          <CampaignsTable data={campaignData} />
+          <CampaignsTable
+            data={campaignData}
+            handleCampaignClick={handleCampaignClick}
+          />
         </>
       )}
     </>

--- a/src/components/CampaignsTable.tsx
+++ b/src/components/CampaignsTable.tsx
@@ -20,7 +20,7 @@ export function CampaignsTable({ data }: { data: CampaignMetadata[] }) {
           <div className="group rounded-md">
             <div
               className={
-                'h-[400px] overflow-y-auto overflow-x-hidden border border-gray-50 bg-gray-50 shadow-lg rounded-md group-hover:bg-gray-100 group-hover:shadow-lg'
+                'h-[380px] overflow-y-auto overflow-x-hidden border border-gray-50 bg-gray-50 shadow-lg rounded-md group-hover:bg-gray-100 group-hover:shadow-lg'
               }
             >
               <div className={'px-4 sm:px-6 lg:px-8 block'}>

--- a/src/components/CampaignsTable.tsx
+++ b/src/components/CampaignsTable.tsx
@@ -1,0 +1,88 @@
+import { CampaignMetadata } from '../lib/types';
+
+export function CampaignsTable({ data }: { data: CampaignMetadata[] }) {
+  return (
+    <div className="px-4 sm:px-6 lg:px-8 block">
+      <div className="sm:flex sm:items-center">
+        <div className="sm:flex-auto">
+          <h1 className="text-base font-semibold leading-6 text-gray-900">
+            Campaigns
+          </h1>
+          <p className="mt-2 text-sm text-gray-700">
+            A list of all the campaigns to which your account has access.
+          </p>
+        </div>
+      </div>
+      <div className="-mx-4 mt-8 sm:-mx-0">
+        <table className="min-w-full divide-y divide-gray-300">
+          <thead>
+            <tr>
+              <th
+                scope="col"
+                className="hidden sm:block py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-0"
+              >
+                Ad Title
+              </th>
+              <th
+                scope="col"
+                className="sm:hidden py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-0"
+              >
+                Ads
+              </th>
+              <th
+                scope="col"
+                className="hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 md:table-cell"
+              >
+                Start date
+              </th>
+              <th
+                scope="col"
+                className="hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 sm:table-cell"
+              >
+                Budget
+              </th>
+              <th
+                scope="col"
+                className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+              >
+                Status
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200 bg-white">
+            {data.map((campaign) => (
+              <tr key={campaign.adTitle}>
+                <td className="w-full max-w-0 py-4 pl-4 pr-3 text-sm font-normal text-gray-800 sm:w-auto sm:max-w-none sm:pl-0 text-left">
+                  {campaign.adTitle}
+                  <dl className="font-normal md:hidden">
+                    <dt className="sr-only">Start date</dt>
+                    <dd className="mt-1 truncate text-gray-700 text-left md:hidden">
+                      {new Date().toISOString().slice(0, 10)}
+                    </dd>
+                    <dt className="sr-only sm:hidden">Budget</dt>
+                    <dd className="mt-1 truncate text-gray-500 sm:hidden">
+                      {campaign.budget}
+                    </dd>
+                  </dl>
+                </td>
+                <td className="hidden px-3 py-4 text-sm text-gray-500 md:table-cell text-left">
+                  {new Date().toISOString().slice(0, 10)}
+                </td>
+                <td className="hidden px-3 py-4 text-sm text-gray-500 sm:table-cell text-left">
+                  {campaign.budget}
+                </td>
+                <td className="px-3 py-4 text-sm text-gray-500 text-left">
+                  {campaign.isActive
+                    ? 'Running'
+                    : campaign.receiptId
+                    ? 'Completed'
+                    : 'Inactive'}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/components/CampaignsTable.tsx
+++ b/src/components/CampaignsTable.tsx
@@ -1,7 +1,11 @@
 import { useState } from 'react';
-import { CampaignMetadata } from '../lib/types';
+import { CampaignDummyData, CampaignData } from '../lib/types';
 
-export function CampaignsTable({ data }: { data: CampaignMetadata[] }) {
+export function CampaignsTable({
+  data,
+}: {
+  data: CampaignData[] | CampaignDummyData[];
+}) {
   const [isShowing, setIsShowing] = useState(true);
   return (
     <>

--- a/src/components/CampaignsTable.tsx
+++ b/src/components/CampaignsTable.tsx
@@ -34,25 +34,25 @@ export function CampaignsTable({
                       <tr className="">
                         <th
                           scope="col"
-                          className="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-0 sticky top-0 bg-gray-50 group-hover:bg-gray-100 rounded-md"
+                          className="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-0 sticky top-0 bg-gray-50 group-hover:bg-gray-100 rounded-md select-none"
                         >
                           Ads
                         </th>
                         <th
                           scope="col"
-                          className="hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 md:table-cell sticky top-0 bg-gray-50 group-hover:bg-gray-100 rounded-md"
+                          className="hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 md:table-cell sticky top-0 bg-gray-50 group-hover:bg-gray-100 rounded-md select-none"
                         >
                           Campaign ID
                         </th>
                         <th
                           scope="col"
-                          className="hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 sm:table-cell sticky top-0 bg-gray-50 group-hover:bg-gray-100 rounded-md"
+                          className="hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 sm:table-cell sticky top-0 bg-gray-50 group-hover:bg-gray-100 rounded-md select-none"
                         >
                           Budget
                         </th>
                         <th
                           scope="col"
-                          className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 sticky top-0 bg-gray-50 group-hover:bg-gray-100 rounded-md"
+                          className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 sticky top-0 bg-gray-50 group-hover:bg-gray-100 rounded-md select-none"
                         >
                           Status
                         </th>

--- a/src/components/CampaignsTable.tsx
+++ b/src/components/CampaignsTable.tsx
@@ -1,10 +1,15 @@
-import { useState } from 'react';
+import { useState, MouseEvent } from 'react';
 import { CampaignDummyData, CampaignData } from '../lib/types';
 
 export function CampaignsTable({
   data,
+  handleCampaignClick,
 }: {
   data: CampaignData[] | CampaignDummyData[];
+  handleCampaignClick: (
+    event: MouseEvent<HTMLButtonElement>,
+    data: CampaignData | CampaignDummyData
+  ) => void;
 }) {
   const [isShowing, setIsShowing] = useState(true);
   return (
@@ -34,33 +39,41 @@ export function CampaignsTable({
                       <tr className="">
                         <th
                           scope="col"
-                          className="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-0 sticky top-0 bg-gray-50 group-hover:bg-gray-100 rounded-md select-none"
+                          className="py-3.5 pl-4 pr-3 pb-2 text-left text-sm font-semibold text-gray-900 sm:pl-0 sticky top-0 bg-gray-50 group-hover:bg-gray-100 rounded-md select-none"
                         >
                           Ads
                         </th>
                         <th
                           scope="col"
-                          className="hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 md:table-cell sticky top-0 bg-gray-50 group-hover:bg-gray-100 rounded-md select-none"
+                          className="hidden px-3 py-3.5 pb-2 text-left text-sm font-semibold text-gray-900 md:table-cell sticky top-0 bg-gray-50 group-hover:bg-gray-100 rounded-md select-none"
                         >
                           Campaign ID
                         </th>
                         <th
                           scope="col"
-                          className="hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 sm:table-cell sticky top-0 bg-gray-50 group-hover:bg-gray-100 rounded-md select-none"
+                          className="hidden px-3 py-3.5 pb-2 text-left text-sm font-semibold text-gray-900 sm:table-cell sticky top-0 bg-gray-50 group-hover:bg-gray-100 rounded-md select-none"
                         >
                           Budget
                         </th>
                         <th
                           scope="col"
-                          className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 sticky top-0 bg-gray-50 group-hover:bg-gray-100 rounded-md select-none"
+                          className="px-3 py-3.5 pb-2 text-left text-sm font-semibold text-gray-900 sticky top-0 bg-gray-50 group-hover:bg-gray-100 rounded-md select-none"
                         >
                           Status
                         </th>
                       </tr>
                     </thead>
                     <tbody className="divide-y divide-gray-200 bg-gray-50 group-hover:bg-gray-100 rounded-md">
-                      {data.map((campaign) => (
-                        <tr key={campaign.adTitle}>
+                      {data.map((campaign, index) => (
+                        <tr
+                          className="cursor-pointer hover:text-gray-200"
+                          key={`${campaign.adTitle}-${index}`}
+                          onClick={(e) => {
+                            e.preventDefault();
+                            /* @ts-ignore */
+                            handleCampaignClick(e, campaign);
+                          }}
+                        >
                           <td className="w-full max-w-0 py-4 pl-4 pr-3 text-sm font-normal text-gray-800 sm:w-auto sm:max-w-none sm:pl-0 text-left">
                             {campaign.adTitle}
                             <dl className="font-normal md:hidden">

--- a/src/components/CampaignsTable.tsx
+++ b/src/components/CampaignsTable.tsx
@@ -1,87 +1,99 @@
+import { useState } from 'react';
 import { CampaignMetadata } from '../lib/types';
 
 export function CampaignsTable({ data }: { data: CampaignMetadata[] }) {
+  const [isShowing, setIsShowing] = useState(true);
   return (
     <>
-      <div className="h-[400px] overflow-y-auto overflow-x-hidden">
-        <div className="px-4 sm:px-6 lg:px-8 block">
-          <div className="sm:flex sm:items-center">
-            <div className="sm:flex-auto">
-              <h1 className="text-base font-semibold leading-6 text-gray-900">
-                Campaigns
-              </h1>
-              <p className="mt-2 text-sm text-gray-700">
-                A list of all the campaigns to which your account has access.
-              </p>
+      <div className="w-full text-left">
+        <button
+          className="relative overflow-hidden rounded-md bg-slate-50 px-2 py-1 text-xs md:text-sm shadow sm:px-3 sm:py-2 hover:bg-slate-200 hover:shadow-lg border border-1 border-transparent dark:bg-slate-700 dark:text-slate-100 dark:hover:bg-slate-600 mb-2"
+          onClick={() => {
+            setIsShowing(!isShowing);
+          }}
+        >
+          {!isShowing ? 'Show table' : `Collapse table`}
+        </button>
+      </div>
+      {isShowing ? (
+        <>
+          <div className="group rounded-md">
+            <div
+              className={
+                'h-[400px] overflow-y-auto overflow-x-hidden border border-gray-50 bg-gray-50 shadow-lg rounded-md group-hover:bg-gray-100 group-hover:shadow-lg'
+              }
+            >
+              <div className={'px-4 sm:px-6 lg:px-8 block'}>
+                <div className="-mx-4 mt-8 sm:-mx-0">
+                  <table className="min-w-full divide-y divide-gray-300">
+                    <thead className="">
+                      <tr className="">
+                        <th
+                          scope="col"
+                          className="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-0 sticky top-0 bg-gray-50 group-hover:bg-gray-100 rounded-md"
+                        >
+                          Ads
+                        </th>
+                        <th
+                          scope="col"
+                          className="hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 md:table-cell sticky top-0 bg-gray-50 group-hover:bg-gray-100 rounded-md"
+                        >
+                          Start date
+                        </th>
+                        <th
+                          scope="col"
+                          className="hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 sm:table-cell sticky top-0 bg-gray-50 group-hover:bg-gray-100 rounded-md"
+                        >
+                          Budget
+                        </th>
+                        <th
+                          scope="col"
+                          className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 sticky top-0 bg-gray-50 group-hover:bg-gray-100 rounded-md"
+                        >
+                          Status
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-gray-200 bg-gray-50 group-hover:bg-gray-100 rounded-md">
+                      {data.map((campaign) => (
+                        <tr key={campaign.adTitle}>
+                          <td className="w-full max-w-0 py-4 pl-4 pr-3 text-sm font-normal text-gray-800 sm:w-auto sm:max-w-none sm:pl-0 text-left">
+                            {campaign.adTitle}
+                            <dl className="font-normal md:hidden">
+                              <dt className="sr-only">Start date</dt>
+                              <dd className="mt-1 truncate text-gray-700 text-left md:hidden">
+                                {new Date().toISOString().slice(0, 10)}
+                              </dd>
+                              <dt className="sr-only sm:hidden">Budget</dt>
+                              <dd className="mt-1 truncate text-gray-500 sm:hidden">
+                                {campaign.budget}
+                              </dd>
+                            </dl>
+                          </td>
+                          <td className="hidden px-3 py-4 text-sm text-gray-500 md:table-cell text-left">
+                            {new Date().toISOString().slice(0, 10)}
+                          </td>
+                          <td className="hidden px-3 py-4 text-sm text-gray-500 sm:table-cell text-left">
+                            {campaign.budget}
+                          </td>
+                          <td className="px-3 py-4 text-sm text-gray-500 text-left">
+                            {campaign.isActive
+                              ? 'Running'
+                              : campaign.receiptId
+                              ? 'Completed'
+                              : 'Inactive'}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
             </div>
           </div>
-          <div className="-mx-4 mt-8 sm:-mx-0">
-            <table className="min-w-full divide-y divide-gray-300">
-              <thead className="">
-                <tr className="">
-                  <th
-                    scope="col"
-                    className="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-0 sticky top-0 bg-white border-b border-gray-400"
-                  >
-                    Ads
-                  </th>
-                  <th
-                    scope="col"
-                    className="hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 md:table-cell sticky top-0 bg-white border-b border-gray-400"
-                  >
-                    Start date
-                  </th>
-                  <th
-                    scope="col"
-                    className="hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 sm:table-cell sticky top-0 bg-white border-b border-gray-400"
-                  >
-                    Budget
-                  </th>
-                  <th
-                    scope="col"
-                    className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 sticky top-0 bg-white border-b border-gray-400"
-                  >
-                    Status
-                  </th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-gray-200 bg-white">
-                {data.map((campaign) => (
-                  <tr key={campaign.adTitle}>
-                    <td className="w-full max-w-0 py-4 pl-4 pr-3 text-sm font-normal text-gray-800 sm:w-auto sm:max-w-none sm:pl-0 text-left">
-                      {campaign.adTitle}
-                      <dl className="font-normal md:hidden">
-                        <dt className="sr-only">Start date</dt>
-                        <dd className="mt-1 truncate text-gray-700 text-left md:hidden">
-                          {new Date().toISOString().slice(0, 10)}
-                        </dd>
-                        <dt className="sr-only sm:hidden">Budget</dt>
-                        <dd className="mt-1 truncate text-gray-500 sm:hidden">
-                          {campaign.budget}
-                        </dd>
-                      </dl>
-                    </td>
-                    <td className="hidden px-3 py-4 text-sm text-gray-500 md:table-cell text-left">
-                      {new Date().toISOString().slice(0, 10)}
-                    </td>
-                    <td className="hidden px-3 py-4 text-sm text-gray-500 sm:table-cell text-left">
-                      {campaign.budget}
-                    </td>
-                    <td className="px-3 py-4 text-sm text-gray-500 text-left">
-                      {campaign.isActive
-                        ? 'Running'
-                        : campaign.receiptId
-                        ? 'Completed'
-                        : 'Inactive'}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </div>
-      </div>
-      <div className="pb-12" />
+          <div className="pb-12" />
+        </>
+      ) : null}
     </>
   );
 }

--- a/src/components/CampaignsTable.tsx
+++ b/src/components/CampaignsTable.tsx
@@ -2,87 +2,86 @@ import { CampaignMetadata } from '../lib/types';
 
 export function CampaignsTable({ data }: { data: CampaignMetadata[] }) {
   return (
-    <div className="px-4 sm:px-6 lg:px-8 block">
-      <div className="sm:flex sm:items-center">
-        <div className="sm:flex-auto">
-          <h1 className="text-base font-semibold leading-6 text-gray-900">
-            Campaigns
-          </h1>
-          <p className="mt-2 text-sm text-gray-700">
-            A list of all the campaigns to which your account has access.
-          </p>
+    <>
+      <div className="h-[400px] overflow-y-auto overflow-x-hidden">
+        <div className="px-4 sm:px-6 lg:px-8 block">
+          <div className="sm:flex sm:items-center">
+            <div className="sm:flex-auto">
+              <h1 className="text-base font-semibold leading-6 text-gray-900">
+                Campaigns
+              </h1>
+              <p className="mt-2 text-sm text-gray-700">
+                A list of all the campaigns to which your account has access.
+              </p>
+            </div>
+          </div>
+          <div className="-mx-4 mt-8 sm:-mx-0">
+            <table className="min-w-full divide-y divide-gray-300">
+              <thead className="">
+                <tr className="">
+                  <th
+                    scope="col"
+                    className="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-0 sticky top-0 bg-white border-b border-gray-400"
+                  >
+                    Ads
+                  </th>
+                  <th
+                    scope="col"
+                    className="hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 md:table-cell sticky top-0 bg-white border-b border-gray-400"
+                  >
+                    Start date
+                  </th>
+                  <th
+                    scope="col"
+                    className="hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 sm:table-cell sticky top-0 bg-white border-b border-gray-400"
+                  >
+                    Budget
+                  </th>
+                  <th
+                    scope="col"
+                    className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 sticky top-0 bg-white border-b border-gray-400"
+                  >
+                    Status
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200 bg-white">
+                {data.map((campaign) => (
+                  <tr key={campaign.adTitle}>
+                    <td className="w-full max-w-0 py-4 pl-4 pr-3 text-sm font-normal text-gray-800 sm:w-auto sm:max-w-none sm:pl-0 text-left">
+                      {campaign.adTitle}
+                      <dl className="font-normal md:hidden">
+                        <dt className="sr-only">Start date</dt>
+                        <dd className="mt-1 truncate text-gray-700 text-left md:hidden">
+                          {new Date().toISOString().slice(0, 10)}
+                        </dd>
+                        <dt className="sr-only sm:hidden">Budget</dt>
+                        <dd className="mt-1 truncate text-gray-500 sm:hidden">
+                          {campaign.budget}
+                        </dd>
+                      </dl>
+                    </td>
+                    <td className="hidden px-3 py-4 text-sm text-gray-500 md:table-cell text-left">
+                      {new Date().toISOString().slice(0, 10)}
+                    </td>
+                    <td className="hidden px-3 py-4 text-sm text-gray-500 sm:table-cell text-left">
+                      {campaign.budget}
+                    </td>
+                    <td className="px-3 py-4 text-sm text-gray-500 text-left">
+                      {campaign.isActive
+                        ? 'Running'
+                        : campaign.receiptId
+                        ? 'Completed'
+                        : 'Inactive'}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </div>
       </div>
-      <div className="-mx-4 mt-8 sm:-mx-0">
-        <table className="min-w-full divide-y divide-gray-300">
-          <thead>
-            <tr>
-              <th
-                scope="col"
-                className="hidden sm:block py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-0"
-              >
-                Ad Title
-              </th>
-              <th
-                scope="col"
-                className="sm:hidden py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-0"
-              >
-                Ads
-              </th>
-              <th
-                scope="col"
-                className="hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 md:table-cell"
-              >
-                Start date
-              </th>
-              <th
-                scope="col"
-                className="hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 sm:table-cell"
-              >
-                Budget
-              </th>
-              <th
-                scope="col"
-                className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
-              >
-                Status
-              </th>
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-gray-200 bg-white">
-            {data.map((campaign) => (
-              <tr key={campaign.adTitle}>
-                <td className="w-full max-w-0 py-4 pl-4 pr-3 text-sm font-normal text-gray-800 sm:w-auto sm:max-w-none sm:pl-0 text-left">
-                  {campaign.adTitle}
-                  <dl className="font-normal md:hidden">
-                    <dt className="sr-only">Start date</dt>
-                    <dd className="mt-1 truncate text-gray-700 text-left md:hidden">
-                      {new Date().toISOString().slice(0, 10)}
-                    </dd>
-                    <dt className="sr-only sm:hidden">Budget</dt>
-                    <dd className="mt-1 truncate text-gray-500 sm:hidden">
-                      {campaign.budget}
-                    </dd>
-                  </dl>
-                </td>
-                <td className="hidden px-3 py-4 text-sm text-gray-500 md:table-cell text-left">
-                  {new Date().toISOString().slice(0, 10)}
-                </td>
-                <td className="hidden px-3 py-4 text-sm text-gray-500 sm:table-cell text-left">
-                  {campaign.budget}
-                </td>
-                <td className="px-3 py-4 text-sm text-gray-500 text-left">
-                  {campaign.isActive
-                    ? 'Running'
-                    : campaign.receiptId
-                    ? 'Completed'
-                    : 'Inactive'}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-    </div>
+      <div className="pb-12" />
+    </>
   );
 }

--- a/src/components/CampaignsTable.tsx
+++ b/src/components/CampaignsTable.tsx
@@ -38,7 +38,7 @@ export function CampaignsTable({ data }: { data: CampaignMetadata[] }) {
                           scope="col"
                           className="hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 md:table-cell sticky top-0 bg-gray-50 group-hover:bg-gray-100 rounded-md"
                         >
-                          Start date
+                          Campaign ID
                         </th>
                         <th
                           scope="col"
@@ -60,9 +60,9 @@ export function CampaignsTable({ data }: { data: CampaignMetadata[] }) {
                           <td className="w-full max-w-0 py-4 pl-4 pr-3 text-sm font-normal text-gray-800 sm:w-auto sm:max-w-none sm:pl-0 text-left">
                             {campaign.adTitle}
                             <dl className="font-normal md:hidden">
-                              <dt className="sr-only">Start date</dt>
+                              <dt className="sr-only">Campaign ID</dt>
                               <dd className="mt-1 truncate text-gray-700 text-left md:hidden">
-                                {new Date().toISOString().slice(0, 10)}
+                                {campaign.pid}
                               </dd>
                               <dt className="sr-only sm:hidden">Budget</dt>
                               <dd className="mt-1 truncate text-gray-500 sm:hidden">
@@ -71,7 +71,7 @@ export function CampaignsTable({ data }: { data: CampaignMetadata[] }) {
                             </dl>
                           </td>
                           <td className="hidden px-3 py-4 text-sm text-gray-500 md:table-cell text-left">
-                            {new Date().toISOString().slice(0, 10)}
+                            {campaign.pid}
                           </td>
                           <td className="hidden px-3 py-4 text-sm text-gray-500 sm:table-cell text-left">
                             {campaign.budget}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -341,7 +341,7 @@ export function PromoDashboard({
                   data={statsCampaignsData}
                   statsHighlightTimeseries={statsHighlightCampaignsTimeseries}
                   statsHighlightMetricName={clickedStatsCampaignsClassName}
-                  campaignData={campaignsData as CampaignData[]}
+                  campaignData={campaignsData}
                   handleCampaignDetailBackOnClick={
                     handleCampaignDetailBackOnClick
                   }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -240,6 +240,7 @@ export function PromoDashboard({
     event: MouseEvent<HTMLButtonElement>,
     data: CampaignData | CampaignDummyData
   ) => {
+    console.log(`handleCampaignOnClick::${JSON.stringify(data)}`);
     if (typeof handleCampaignClick !== 'undefined') {
       handleCampaignClick(event, data);
     }
@@ -341,7 +342,7 @@ export function PromoDashboard({
                   data={statsCampaignsData}
                   statsHighlightTimeseries={statsHighlightCampaignsTimeseries}
                   statsHighlightMetricName={clickedStatsCampaignsClassName}
-                  campaignData={campaignsData}
+                  campaignData={sortedCampaignsData}
                   handleCampaignClick={handleCampaignOnClick}
                   handleCampaignDetailBackOnClick={
                     handleCampaignDetailBackOnClick

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -341,6 +341,7 @@ export function PromoDashboard({
                   data={statsCampaignsData}
                   statsHighlightTimeseries={statsHighlightCampaignsTimeseries}
                   statsHighlightMetricName={clickedStatsCampaignsClassName}
+                  campaignData={campaignsData as CampaignData[]}
                   handleCampaignDetailBackOnClick={
                     handleCampaignDetailBackOnClick
                   }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -342,6 +342,7 @@ export function PromoDashboard({
                   statsHighlightTimeseries={statsHighlightCampaignsTimeseries}
                   statsHighlightMetricName={clickedStatsCampaignsClassName}
                   campaignData={campaignsData}
+                  handleCampaignClick={handleCampaignOnClick}
                   handleCampaignDetailBackOnClick={
                     handleCampaignDetailBackOnClick
                   }

--- a/src/lib/coerce.ts
+++ b/src/lib/coerce.ts
@@ -425,31 +425,33 @@ export function modifySingleCampaignDataForDownload(
   let chartJsData = generateEmptyPromoApiDataForChartJs();
   let modifiedData: DownloadableCampaignStatsSample[] = [];
   if (typeof data !== 'undefined') {
-    data.forEach((pckg: CampaignStatsData) => {
-      const chartData = pckg?.chartData;
-      chartJsData.updatedTime = chartData.labels;
-      // @ts-ignore
-      chartJsData[pckg.name.toLowerCase()] = chartData.data;
-    });
-    let modifiedObject = {
-      ...chartJsData,
-      pid,
-    };
-    let timestamps = modifiedObject.updatedTime;
-    timestamps.forEach((timestamp, index) => {
-      const mdtmp = {
-        pid: pid || '',
-        updatedTime: timestamp || '',
-        spend: modifiedObject.spend[index],
-        views: modifiedObject?.views[index],
-        clicks: modifiedObject?.clicks[index],
-        cpc: modifiedObject?.cpc[index],
-        cpm: modifiedObject?.cpm[index],
-        ctr: modifiedObject?.ctr[index],
-        cpv: modifiedObject?.cpv[index],
+    if (Array.isArray(data)) {
+      data.forEach((pckg: CampaignStatsData) => {
+        const chartData = pckg?.chartData;
+        chartJsData.updatedTime = chartData.labels;
+        // @ts-ignore
+        chartJsData[pckg.name.toLowerCase()] = chartData.data;
+      });
+      let modifiedObject = {
+        ...chartJsData,
+        pid,
       };
-      modifiedData.push(mdtmp);
-    });
-    return modifiedData;
+      let timestamps = modifiedObject.updatedTime;
+      timestamps.forEach((timestamp, index) => {
+        const mdtmp = {
+          pid: pid || '',
+          updatedTime: timestamp || '',
+          spend: modifiedObject.spend[index],
+          views: modifiedObject?.views[index],
+          clicks: modifiedObject?.clicks[index],
+          cpc: modifiedObject?.cpc[index],
+          cpm: modifiedObject?.cpm[index],
+          ctr: modifiedObject?.ctr[index],
+          cpv: modifiedObject?.cpv[index],
+        };
+        modifiedData.push(mdtmp);
+      });
+      return modifiedData;
+    }
   }
 }

--- a/test/components/CampaignsTable.tsx
+++ b/test/components/CampaignsTable.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CampaignsChart } from '../../src/components/CampaignsChart';
+import { campaignStubData } from '../cms.data';
+import { options } from '../../src/lib/options';
+import {
+  mockAllIsIntersecting,
+  setupIntersectionMocking,
+  resetIntersectionMocking,
+} from 'react-intersection-observer/test-utils';
+
+window.scrollTo = jest.fn();
+
+beforeEach(() => {
+  setupIntersectionMocking(jest.fn);
+});
+afterEach(() => {
+  resetIntersectionMocking();
+});
+afterAll(() => {
+  jest.clearAllMocks();
+});
+
+describe('CampaignsChart', () => {
+  it('renders full data without crashing', () => {
+    mockAllIsIntersecting(true);
+    render(
+      <CampaignsChart
+        timePeriods={options.timePeriods}
+        selectedChartButton="1 month"
+        statsHighlightTimeseries={campaignStubData[0].stats[0]}
+        handleChartButtonOnClick={() => null}
+      />
+    );
+    const campaignsTableItem = screen.getByText(campaignStubData[0].pid);
+    expect(campaignsTableItem).toBeDefined();
+    fireEvent.click(campaignsTableItem);
+  });
+});


### PR DESCRIPTION
This adds the initial components and infrastructure for displaying a table of campaign metadata. It includes a collapse/hide button and allows for scrolling within the element itself.

![image](https://github.com/Tincre/promo-dashboard/assets/16545607/7b49baf8-89be-4376-a122-a209fcc75a16)
