### PR TITLE
Feature/add campaign date discovery

### DIFF
--- a/example/nextjs/test.data.js
+++ b/example/nextjs/test.data.js
@@ -192,6 +192,7 @@ export const campaignStubData = [
         },
       ],
     },
+    startDate: '2023-07-15',
     target: 'https://b00st.com',
     creativeUrls: [
       'https://res.cloudinary.com/b00st/image/upload/v1683411202/B00STButton/f4tcvy2rfc5p5vbftkv9.jpg',
@@ -207,6 +208,7 @@ export const campaignStubData = [
     pid: 'fdfb0066',
     adTitle: 'Music marketing TEST flat pricing',
     budget: 45,
+    startDate: '2023-07-19',
     data: {
       totals: [
         {
@@ -1319,6 +1321,7 @@ export const campaignStubData = [
     pid: '6cb703dd',
     adTitle: 'Music marketing TEST 2',
     budget: 45,
+    startDate: '2023-07-18',
     data: {
       totals: [
         {
@@ -2464,6 +2467,7 @@ export const campaignStubData = [
     pid: '7e91fb85',
     adTitle: '🆕 Born and Raised b00st.com TEST',
     budget: 50,
+    startDate: '2023-07-16',
     data: {
       totals: [
         {
@@ -3182,6 +3186,7 @@ export const campaignStubData = [
     pid: '1d73d2d1',
     adTitle: '✅ TEST check flat payment do not run',
     budget: 135,
+    startDate: '2023-07-20',
     data: {
       totals: [
         {
@@ -3238,6 +3243,7 @@ export const campaignStubData = [
     pid: '3d9c7e84',
     adTitle: 'GH',
     budget: 4636,
+    startDate: '2023-07-18',
     data: {
       meta: [
         {
@@ -3442,6 +3448,8 @@ export const campaignStubData = [
     pid: '3d9c7e84',
     adTitle: 'GH',
     budget: 4636,
+    startDate: '2023-07-18',
+
     data: {
       meta: [
         {
@@ -3646,6 +3654,8 @@ export const campaignStubData = [
     pid: '3d9c7e84',
     adTitle: 'GH',
     budget: 4636,
+    startDate: '2023-07-15',
+
     data: {
       meta: [
         {
@@ -3850,6 +3860,8 @@ export const campaignStubData = [
     pid: '3d9c7e84',
     adTitle: 'GH',
     budget: 4636,
+    startDate: '2023-07-15',
+
     data: {
       meta: [
         {
@@ -4054,6 +4066,8 @@ export const campaignStubData = [
     pid: '3d9c7e84',
     adTitle: 'GH',
     budget: 4636,
+    startDate: '2023-07-15',
+
     data: {
       meta: [
         {
@@ -4258,6 +4272,8 @@ export const campaignStubData = [
     pid: '3d9c7e84',
     adTitle: 'GH',
     budget: 4636,
+    startDate: '2023-07-15',
+
     data: {
       meta: [
         {
@@ -4462,6 +4478,8 @@ export const campaignStubData = [
     pid: '3d9c7e84',
     adTitle: 'GH',
     budget: 4636,
+    startDate: '2023-07-15',
+
     data: {
       meta: [
         {

--- a/src/components/Campaign.tsx
+++ b/src/components/Campaign.tsx
@@ -160,6 +160,7 @@ export function Campaign({
               ) : (
                 <video
                   muted
+                  preload="none"
                   controls
                   className="mx-auto h-32 w-full flex-shrink-0 rounded-b-md rounded-t-sm object-cover px-2"
                 >

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -27,7 +27,7 @@ import { Spinner } from './components/Spinner';
 import { CampaignList } from './components/CampaignList';
 import { DashboardContainer } from './components/DashboardContainer';
 import {
-  sortCampaignDataOnIsActiveAndReceiptId,
+  sortCampaignDataOnIsActiveAndReceiptIdByDate,
   numActiveCampaigns,
 } from './lib/sort';
 import { aggregateChartData, replaceDataParamForChartData } from './lib/coerce';
@@ -122,12 +122,11 @@ export function PromoDashboard({
     if (typeof campaignsData !== 'undefined') {
       setSortedCampaignsData(
         replaceDataParamForChartData(
-          sortCampaignDataOnIsActiveAndReceiptId(campaignsData)
+          sortCampaignDataOnIsActiveAndReceiptIdByDate(campaignsData)
         )
       );
     }
   }, [campaignsData, setSortedCampaignsData]);
-
   useEffect(() => {
     if (typeof campaignDetailData !== 'undefined') {
       setPromoData(campaignDetailData);

--- a/src/lib/compareDates.ts
+++ b/src/lib/compareDates.ts
@@ -1,0 +1,26 @@
+/* Copyright Tincre (Musicfox, Inc)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+import { CampaignData, CampaignDummyData } from './types';
+
+/*
+ * Given data packages compare their dates.
+ *
+ */
+export function compareDates(
+  a: CampaignData | CampaignDummyData,
+  b: CampaignData | CampaignDummyData,
+  isAscending: boolean = true
+) {
+  let today = new Date();
+  let aStartDate =
+    typeof a.startDate !== 'undefined' ? new Date(a.startDate) : today;
+  let bStartDate =
+    typeof b.startDate !== 'undefined' ? new Date(b.startDate) : today;
+  return !isAscending
+    ? aStartDate.getTime() - bStartDate.getTime()
+    : bStartDate.getTime() - aStartDate.getTime();
+}

--- a/src/lib/disectChartData.ts
+++ b/src/lib/disectChartData.ts
@@ -9,12 +9,12 @@ export function disectChartData(
   data: (string | number | null)[],
   length: number
 ) {
-  const endLabelIdx = labels.length - 1;
-  const endDataIdx = data.length - 1;
-  const startLabelIdx = Math.max(0, endLabelIdx - length);
-  const startDataIdx = Math.max(0, endDataIdx - length);
+  const endLabelSliceIdx = labels.length;
+  const endDataSliceIdx = data.length;
+  const startLabelIdx = Math.max(0, endLabelSliceIdx - length);
+  const startDataIdx = Math.max(0, endDataSliceIdx - length);
   return {
-    labels: labels.slice(startLabelIdx, endLabelIdx),
-    data: data.slice(startDataIdx, endDataIdx),
+    labels: labels.slice(startLabelIdx, endLabelSliceIdx),
+    data: data.slice(startDataIdx, endDataSliceIdx),
   };
 }

--- a/src/lib/sort.ts
+++ b/src/lib/sort.ts
@@ -5,7 +5,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 import { CampaignData, CampaignDummyData } from './types';
-
+import { compareDates } from './compareDates';
 export function sortCampaignDataOnIsActive(
   data: CampaignData[] | CampaignDummyData[]
 ) {
@@ -28,6 +28,42 @@ export function sortCampaignDataOnIsActiveAndReceiptId(
   );
   return newArray;
 }
+
+export function sortCampaignDataOnIsActiveAndReceiptIdByDate(
+  data: CampaignData[] | CampaignDummyData[],
+  isAscending?: boolean
+) {
+  let runningCampaigns: CampaignData[] = [];
+  let completedCampaigns: CampaignData[] = [];
+  let inactiveCampaigns: CampaignData[] = [];
+  let unpaidCampaigns: CampaignData[] = [];
+  data.forEach((campaign: CampaignData | CampaignDummyData) => {
+    if (campaign?.isActive && campaign?.receiptId) {
+      // @ts-ignore
+      runningCampaigns.push(campaign);
+      return;
+    }
+    if (campaign?.isActive && !campaign?.receiptId) {
+      // @ts-ignore
+      unpaidCampaigns.push(campaign);
+      return;
+    }
+    if (!campaign?.isActive && campaign?.receiptId) {
+      // @ts-ignore
+      completedCampaigns.push(campaign);
+      return;
+    } // @ts-ignore
+    inactiveCampaigns.push(campaign);
+  });
+
+  return [
+    ...runningCampaigns.sort((a, b) => compareDates(a, b, isAscending)),
+    ...completedCampaigns.sort((a, b) => compareDates(a, b, isAscending)),
+    ...unpaidCampaigns.sort((a, b) => compareDates(a, b, isAscending)),
+    ...inactiveCampaigns.sort((a, b) => compareDates(a, b, isAscending)),
+  ];
+}
+
 export const numActiveCampaigns = (
   sortedCampaignsData: CampaignData[] | CampaignDummyData[],
   exclusions: string[] = []

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -109,6 +109,7 @@ export interface CampaignMetadata {
   currency?: string;
   isFlat?: boolean;
   usageFee?: string | number;
+  startDate?: string;
 }
 
 export interface CampaignData extends CampaignMetadata {


### PR DESCRIPTION
This adds sorting campaigns automatically by latest date, [better lazy loading for videos](https://web.dev/lazy-loading-video/#main), and fixes a chart display bug for ending dates.