### PR TITLE
:recycle: add creativeUrls on repeat button click #27

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -185,6 +185,7 @@ export function PromoDashboard({
       adCopy: data?.adCopy || data?.description,
       adCallToAction: data?.adCallToAction,
       buttonText: data?.buttonText,
+      creativeUrls: data?.creativeUrls,
     });
     if (typeof setIsRepeatButtonClicked !== 'undefined') {
       setIsRepeatButtonClicked(!isRepeatButtonClicked);


### PR DESCRIPTION
This closes [#27](https://gitlab.com/tincre/promo-dashboard/-/issues/27) by adding the default repeat button click data to include the `creativeUrls` array.

This will allow the Promo Button to receive the array of creative uploaded on campaign submission.