### PR TITLE
Feature/add promo chat depdendency

### DIFF
--- a/example/nextjs/package.json
+++ b/example/nextjs/package.json
@@ -21,6 +21,7 @@
     "@reactour/tour": "^3.2.1",
     "@tincre/promo-button": "^0.7.2",
     "@tincre/promo-button-node": "^0.0.6",
+    "@tincre/promo-chat": "^0.0.7",
     "@tincre/promo-dashboard": "^0.11.3",
     "@types/node": "^17.0.25",
     "@types/react": "^18.0.24",

--- a/example/nextjs/yarn.lock
+++ b/example/nextjs/yarn.lock
@@ -271,6 +271,11 @@
   dependencies:
     "@tincre/promo-node" "^0.1.0"
 
+"@tincre/promo-chat@^0.0.7":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@tincre/promo-chat/-/promo-chat-0.0.7.tgz#61db3f305f1ce7255120c51f8dc23830e1daeae6"
+  integrity sha512-ZIRgaJGYpTZwsRY5Hi84Je5vWcSpGLo6t2houqZs1z9rxY9rqYvTZ8WPd1dgOlprgCgkA+f5aNXzd0TwZue/dw==
+
 "@tincre/promo-dashboard@^0.10.0":
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/@tincre/promo-dashboard/-/promo-dashboard-0.10.1.tgz#43b902784b1b03c131ab3b90b4ca7c843fcf22bd"

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "peerDependencies": {
     "@headlessui/react": "^1.7.17",
     "@heroicons/react": ">=2.0",
+    "@tincre/promo-chat": "^0.0.7",
     "chart.js": ">=3.9",
     "react": ">=16",
     "react-chartjs-2": ">=4.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1558,6 +1558,11 @@
     "@testing-library/dom" "^8.5.0"
     "@types/react-dom" "^18.0.0"
 
+"@tincre/promo-chat@^0.0.7":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@tincre/promo-chat/-/promo-chat-0.0.7.tgz#61db3f305f1ce7255120c51f8dc23830e1daeae6"
+  integrity sha512-ZIRgaJGYpTZwsRY5Hi84Je5vWcSpGLo6t2houqZs1z9rxY9rqYvTZ8WPd1dgOlprgCgkA+f5aNXzd0TwZue/dw==
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"


### PR DESCRIPTION
This adds the [@tincre/promo-chat](https://github.com/Tincre/promo-chat) library as a peer dependency and to the example app. 