### PR TITLE
Feature/refactor promo chat usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,14 +77,19 @@ PROMO_CLIENT_SECRET=
 
 ```jsx
 import { PromoDashboard } from '@tincre/promo-dashboard';
+import { PromoChat } from '@tincre/promo-chat';
 
 <PromoDashboard
   campaignsData={campaignsData}
   campaignDetailData={campaignDetailData || undefined}
   isLoading={false}
   handleRepeatButtonClick={handleRepeatButtonClick || undefined}
+  PromoChat={PromoChat}
 />;
 ```
+
+> `PromoChat` is required to be passed in as a prop so that this library itself
+> doesn't require the explicit dependency.
 
 ##### `campaignsData`
 

--- a/example/nextjs/package.json
+++ b/example/nextjs/package.json
@@ -9,6 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@tailwindcss/typography": "^0.5.10",
+    "@tincre/promo-types": "^0.0.2",
     "markdown-to-jsx": "^7.3.2",
     "next": "^13.0.0",
     "react": "^18.2.0",
@@ -22,8 +24,8 @@
     "@reactour/tour": "^3.2.1",
     "@tincre/promo-button": "^0.7.2",
     "@tincre/promo-button-node": "^0.0.6",
-    "@tincre/promo-chat": "^0.0.7",
-    "@tincre/promo-dashboard": "^0.11.3",
+    "@tincre/promo-chat": "^0.0.15",
+    "@tincre/promo-dashboard": "^0.12.2",
     "@types/node": "^17.0.25",
     "@types/react": "^18.0.24",
     "@types/react-dom": "^18.0.8",
@@ -38,7 +40,7 @@
     "react-hot-toast": "^2.4.0",
     "react-intersection-observer": "^9.5.2",
     "react-json-to-csv": "^1.1.0",
-    "tailwindcss": "^3.2.1",
+    "tailwindcss": "^3.3.5",
     "typescript": "^4.6.3",
     "yup": "^0.32.11"
   }

--- a/example/nextjs/pages/_app.tsx
+++ b/example/nextjs/pages/_app.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import type { AppProps } from 'next/app';
 //import '../../../dist/promo-button.esm.css'; // @tincre/promo-button/bundle.css
 import { TourProvider } from '@reactour/tour';

--- a/example/nextjs/pages/index.tsx
+++ b/example/nextjs/pages/index.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect, MouseEvent } from 'react';
 import type { NextPage } from 'next';
 import Head from 'next/head';
-import { PromoDashboard } from '@tincre/promo-dashboard';
-//import { PromoDashboard } from '../../../dist';
+//import { PromoDashboard } from '@tincre/promo-dashboard';
+import { PromoDashboard } from '../../../dist';
+import { PromoChat } from '@tincre/promo-chat';
 //import { campaignStubData } from '../cms.data';
 import { campaignStubData } from '../test.data';
 import { useTour } from '@reactour/tour';
@@ -41,7 +42,7 @@ const Home: NextPage = () => {
         <link rel="icon" href="/favicon.ico" />
       </Head>
 
-      <main className="my-8" id="main">
+      <div className="my-8" id="main">
         <div className="text-center">
           <h1 className="text-3xl font-bold text-center">
             Welcome to the{' '}
@@ -68,13 +69,13 @@ const Home: NextPage = () => {
             </a>
           </p>
         </div>
-        <div style={{ textAlign: 'center', marginTop: '20px' }}>
+        <div className="text-center" id="main">
           <p style={{ marginTop: '20px', marginBottom: '10px' }}>
             <code className="font-bold">
               npm install @tincre/promo-dashboard
             </code>
           </p>
-          <p className="py-4">
+          <p className="pt-4">
             <button
               onClick={() => setIsOpen(true)}
               className="text-indigo-50 hover:text-indigo-900 border border-1 border-indigo-700 hover:border-indigo-300 py-3 px-5 rounded-md hover:bg-indigo-100 hover:text-indigo-700 bg-indigo-700"
@@ -82,7 +83,7 @@ const Home: NextPage = () => {
               Start tour
             </button>
           </p>
-          <p className="py-4">
+          <p className="pt-4">
             <button
               onClick={() => setIsLoading(!isLoading)}
               className="text-indigo-50 hover:text-indigo-900 border border-1 border-indigo-700 hover:border-indigo-300 py-3 px-5 rounded-md hover:bg-indigo-100 hover:text-indigo-700 bg-indigo-700"
@@ -90,13 +91,14 @@ const Home: NextPage = () => {
               isLoading
             </button>
           </p>
-          <PromoDashboard
-            campaignsData={campaignStubData /* @ts-ignore */}
-            handleRepeatButtonClick={handleRepeatButtonClick /* @ts-ignore */}
-            isLoading={isLoading}
-          />
         </div>
-      </main>
+        <PromoDashboard
+          campaignsData={campaignStubData /* @ts-ignore */}
+          handleRepeatButtonClick={handleRepeatButtonClick /* @ts-ignore */}
+          isLoading={isLoading}
+          PromoChat={PromoChat}
+        />
+      </div>
 
       <footer className="text-center w-full bottom-0 pb-12">
         <a

--- a/example/nextjs/pages/index.tsx
+++ b/example/nextjs/pages/index.tsx
@@ -1,8 +1,8 @@
 import { useState, useEffect, MouseEvent } from 'react';
 import type { NextPage } from 'next';
 import Head from 'next/head';
-//import { PromoDashboard } from '@tincre/promo-dashboard';
-import { PromoDashboard } from '../../../dist';
+import { PromoDashboard } from '@tincre/promo-dashboard';
+//import { PromoDashboard } from '../../../dist';
 import { PromoChat } from '@tincre/promo-chat';
 //import { campaignStubData } from '../cms.data';
 import { campaignStubData } from '../test.data';

--- a/example/nextjs/tailwind.config.js
+++ b/example/nextjs/tailwind.config.js
@@ -3,14 +3,12 @@ module.exports = {
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
     // uncomment for npm @tincre/promo-dashboard installation
-    './node_modules/@tincre/promo-dashboard/*.{js,ts,jsx,tsx}',
-    './node_modules/@tincre/promo-dashboard/**/*.{js,ts,jsx,tsx}',
-    './node_modules/@tincre/promo-button/*',
-    './node_modules/@tincre/promo-button/**/*',
-    '../../dist/*.{js,ts,jsx,tsx}', // remove for deployed apps
+    './node_modules/@tincre/promo-dashboard/**',
+    './node_modules/@tincre/promo-button/**',
+    './node_modules/@tincre/promo-chat/**',
   ],
   theme: {
     extend: {},
   },
-  plugins: [],
+  plugins: ['@tailwindcss/typography'],
 };

--- a/example/nextjs/yarn.lock
+++ b/example/nextjs/yarn.lock
@@ -255,6 +255,16 @@
   dependencies:
     tslib "^2.4.0"
 
+"@tailwindcss/typography@^0.5.10":
+  version "0.5.10"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/typography/-/typography-0.5.10.tgz#2abde4c6d5c797ab49cf47610830a301de4c1e0a"
+  integrity sha512-Pe8BuPJQJd3FfRnm6H0ulKIGoMEQS+Vq01R6M5aCrFB/ccR/shT+0kXLjouGC1gFLm9hopTFN+DMP0pfwRWzPw==
+  dependencies:
+    lodash.castarray "^4.4.0"
+    lodash.isplainobject "^4.0.6"
+    lodash.merge "^4.6.2"
+    postcss-selector-parser "6.0.10"
+
 "@tincre/promo-button-node@^0.0.6":
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/@tincre/promo-button-node/-/promo-button-node-0.0.6.tgz#68a8520d7c63db86b2c911fc7213ffb1a954b073"
@@ -271,15 +281,15 @@
   dependencies:
     "@tincre/promo-node" "^0.1.0"
 
-"@tincre/promo-chat@^0.0.7":
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/@tincre/promo-chat/-/promo-chat-0.0.7.tgz#61db3f305f1ce7255120c51f8dc23830e1daeae6"
-  integrity sha512-ZIRgaJGYpTZwsRY5Hi84Je5vWcSpGLo6t2houqZs1z9rxY9rqYvTZ8WPd1dgOlprgCgkA+f5aNXzd0TwZue/dw==
+"@tincre/promo-chat@^0.0.15":
+  version "0.0.15"
+  resolved "https://registry.yarnpkg.com/@tincre/promo-chat/-/promo-chat-0.0.15.tgz#952977f911810cb747675814f79185d433b7bfce"
+  integrity sha512-Xc+FOKxS4xv1fjWSMMp5FHT1wd+J7O9HuvjzH3SUI9wMmU3BjIDXx3a5GaeVT8aBMtc9lXlNytr1cl5pALwnHA==
 
-"@tincre/promo-dashboard@^0.11.3":
-  version "0.11.13"
-  resolved "https://registry.yarnpkg.com/@tincre/promo-dashboard/-/promo-dashboard-0.11.13.tgz#c1da62333d82ad74af4c37cc2d265172cbc262f5"
-  integrity sha512-xpxS625+HabzyO6XxNZccMz/mpYG485w1QyOjXzyxVjycd2uPCduG6s0K+n85jniUxrRyNNe2DVj0ekVmI2bmA==
+"@tincre/promo-dashboard@^0.12.2":
+  version "0.12.2"
+  resolved "https://registry.yarnpkg.com/@tincre/promo-dashboard/-/promo-dashboard-0.12.2.tgz#2dfca5c271bc925969b40ea1c2d2182554ee01d8"
+  integrity sha512-tTQl0y37RJCirBRnABeqURATj9iuBmY2clsm8RwY/RNyPHcy56oxD0JpWUL5WEDA8F6Dp1doGIqZztYH/5uBAQ==
 
 "@tincre/promo-node@^0.1.0":
   version "0.1.1"
@@ -289,6 +299,11 @@
     "@types/jsonwebtoken" ">=9"
     cross-fetch ">=3.0"
     jsonwebtoken ">=9"
+
+"@tincre/promo-types@^0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@tincre/promo-types/-/promo-types-0.0.2.tgz#e4ae7dd425ba00eca432f4fc8091cbf90f1126ff"
+  integrity sha512-jAeRIuZTzl54g/fybtYb9mtfwVzSMdascYczW5MJjpTa9mlmQbuCo/omtySWCmZTp0GGZWRi61kpSagcwN4yvQ==
 
 "@types/json5@^0.0.29":
   version "0.0.29"
@@ -1809,6 +1824,11 @@ lodash-es@^4.17.21:
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
   integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
 
+lodash.castarray@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.castarray/-/lodash.castarray-4.4.0.tgz#c02513515e309daddd4c24c60cfddcf5976d9115"
+  integrity sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==
+
 lodash.includes@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
@@ -2181,6 +2201,14 @@ postcss-nested@^6.0.1:
   integrity sha512-mEp4xPMi5bSWiMbsgoPfcP74lsWLHkQbZc3sY+jWYd65CUwXrUaTp0fmNpa01ZcETKlIgUdFN/MpS2xZtqL9dQ==
   dependencies:
     postcss-selector-parser "^6.0.11"
+
+postcss-selector-parser@6.0.10:
+  version "6.0.10"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz#79b61e2c0d1bfc2602d549e11d0876256f8df88d"
+  integrity sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==
+  dependencies:
+    cssesc "^3.0.0"
+    util-deprecate "^1.0.2"
 
 postcss-selector-parser@^6.0.11:
   version "6.0.13"
@@ -2558,7 +2586,7 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
-tailwindcss@^3.2.1:
+tailwindcss@^3.3.5:
   version "3.3.5"
   resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-3.3.5.tgz#22a59e2fbe0ecb6660809d9cc5f3976b077be3b8"
   integrity sha512-5SEZU4J7pxZgSkv7FP1zY8i2TIAOooNZ1e/OGtxIEv6GltpoiXUqWvLy89+a10qYTB1N5Ifkuw9lqQkN9sscvA==

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@nastyox/rando.js": "^2.0.5",
     "@size-limit/preset-small-lib": "^8.1.0",
     "@testing-library/react": "^13.4.0",
+    "@tincre/promo-chat": "^0.0.15",
     "@tincre/promo-types": "^0.0.2",
     "@tsconfig/create-react-app": "^1.0.2",
     "@tsconfig/recommended": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "@nastyox/rando.js": "^2.0.5",
     "@size-limit/preset-small-lib": "^8.1.0",
     "@testing-library/react": "^13.4.0",
-    "@tincre/promo-chat": "^0.0.12",
     "@tincre/promo-types": "^0.0.2",
     "@tsconfig/create-react-app": "^1.0.2",
     "@tsconfig/recommended": "^1.0.1",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,7 +9,6 @@ import { useState, useEffect, MouseEvent } from 'react';
 import { Profile } from './components/Profile';
 import { CampaignDetail } from './components/CampaignDetail';
 import { Toaster } from 'react-hot-toast';
-import { PromoChat } from '@tincre/promo-chat';
 import { successToast, failureToast, infoToast } from './lib/notifications';
 import { modifyMultiCampaignsDataForDownload } from './lib/coerce';
 import {
@@ -48,6 +47,7 @@ export function PromoDashboard({
   handleDeleteButtonClick,
   handleCampaignClick,
   handleCampaignDetailBackClick,
+  PromoChat,
   dashboardOptions,
 }: {
   campaignsData: CampaignData[] | CampaignDummyData[];
@@ -77,6 +77,7 @@ export function PromoDashboard({
   handleCampaignDetailBackClick?: (
     event: MouseEvent<HTMLButtonElement>
   ) => void;
+  PromoChat: React.FC<any>;
   dashboardOptions?: DashboardOptions;
 }) {
   const [promoData, setPromoData] = useState<

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,7 +5,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import { useState, useEffect, MouseEvent } from 'react';
+import { useState, useEffect, MouseEvent, FunctionComponent } from 'react';
 import { Profile } from './components/Profile';
 import { CampaignDetail } from './components/CampaignDetail';
 import { Toaster } from 'react-hot-toast';
@@ -77,7 +77,7 @@ export function PromoDashboard({
   handleCampaignDetailBackClick?: (
     event: MouseEvent<HTMLButtonElement>
   ) => void;
-  PromoChat: React.FC<any>;
+  PromoChat: React.FunctionComponent<any>;
   dashboardOptions?: DashboardOptions;
 }) {
   const [promoData, setPromoData] = useState<

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -373,23 +373,7 @@ export function PromoDashboard({
                   dashboardOptions={dbOptions}
                 />
                 {typeof campaignsData !== 'undefined' ? (
-                  <PromoChat
-                    promoData={sortedCampaignsData}
-                    apiRoute={
-                      dashboardOptions?.promoChatApiRoute || '/api/chat'
-                    }
-                    startingAgentMessage={
-                      dashboardOptions?.promoChatStartingAgentMessage
-                    }
-                    agentName={dashboardOptions?.promoChatAgentName}
-                    inputMessagePlaceholder={
-                      dashboardOptions?.promoChatInputMessagePlaceholder
-                    }
-                    executeRecaptcha={
-                      dashboardOptions?.promoChatExecuteRecaptcha
-                    }
-                    supportEmail={`${dashboardOptions?.emailLocalPart}@${dashboardOptions?.emailDomain}`}
-                  />
+                  <div className=""></div>
                 ) : null}
               </>
             )}
@@ -402,18 +386,6 @@ export function PromoDashboard({
               statsHighlightMetricName={clickedStatsClassName}
               handleCampaignDetailBackOnClick={handleCampaignDetailBackOnClick}
               handleStatsHighlightClick={handleStatsHighlightClick}
-            />
-            <PromoChat
-              promoData={promoData}
-              apiRoute={dashboardOptions?.promoChatApiRoute || '/api/chat'}
-              startingAgentMessage={
-                dashboardOptions?.promoChatStartingAgentMessage
-              }
-              agentName={dashboardOptions?.promoChatAgentName}
-              inputMessagePlaceholder={
-                dashboardOptions?.promoChatInputMessagePlaceholder
-              }
-              executeRecaptcha={dashboardOptions?.promoChatExecuteRecaptcha}
             />
           </>
         ) : null}
@@ -431,6 +403,30 @@ export function PromoDashboard({
           email={profileData?.email}
         />
       </DashboardContainer>
+      {!isCampaignClicked ? (
+        <PromoChat
+          promoData={sortedCampaignsData}
+          apiRoute={dashboardOptions?.promoChatApiRoute || '/api/chat'}
+          startingAgentMessage={dashboardOptions?.promoChatStartingAgentMessage}
+          agentName={dashboardOptions?.promoChatAgentName}
+          inputMessagePlaceholder={
+            dashboardOptions?.promoChatInputMessagePlaceholder
+          }
+          executeRecaptcha={dashboardOptions?.promoChatExecuteRecaptcha}
+          supportEmail={`${dashboardOptions?.emailLocalPart}@${dashboardOptions?.emailDomain}`}
+        />
+      ) : typeof promoData !== 'undefined' ? (
+        <PromoChat
+          promoData={promoData}
+          apiRoute={dashboardOptions?.promoChatApiRoute || '/api/chat'}
+          startingAgentMessage={dashboardOptions?.promoChatStartingAgentMessage}
+          agentName={dashboardOptions?.promoChatAgentName}
+          inputMessagePlaceholder={
+            dashboardOptions?.promoChatInputMessagePlaceholder
+          }
+          executeRecaptcha={dashboardOptions?.promoChatExecuteRecaptcha}
+        />
+      ) : null}
       <Toaster position="bottom-center" />
     </>
   );

--- a/test/index.test.tsx
+++ b/test/index.test.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, MouseEvent } from 'react';
 import { screen, render, fireEvent } from '@testing-library/react';
 import { PromoDashboard } from '../src/index';
+import { PromoChat } from '@tincre/promo-chat';
 import { campaignStubData } from './cms.data';
 import { CampaignData, CampaignDummyData, Settings } from '../src/lib/types';
 import {
@@ -26,13 +27,14 @@ describe('PromoDashboard', () => {
   it('renders empty array prop without crashing', () => {
     mockAllIsIntersecting(true);
 
-    render(<PromoDashboard campaignsData={[]} />);
+    render(<PromoDashboard campaignsData={[]} PromoChat={PromoChat} />);
   });
   it('renders full data without crashing', () => {
     mockAllIsIntersecting(true);
 
     render(
       <PromoDashboard
+        PromoChat={PromoChat}
         campaignsData={campaignStubData}
         handleGeneratePaymentLinkButtonClick={() => null}
         isLoading={false}
@@ -51,6 +53,7 @@ describe('PromoDashboard', () => {
 
     render(
       <PromoDashboard
+        PromoChat={PromoChat}
         campaignsData={campaignStubData}
         handleGeneratePaymentLinkButtonClick={() => null}
         isLoading={true}
@@ -78,6 +81,7 @@ describe('PromoDashboard', () => {
 
     render(
       <PromoDashboard
+        PromoChat={PromoChat}
         campaignsData={campaignStubData}
         handleGeneratePaymentLinkButtonClick={() => null}
         handleDeleteButtonClick={handleDeleteButtonClick}
@@ -139,6 +143,7 @@ describe('PromoDashboard', () => {
     });
     render(
       <PromoDashboard
+        PromoChat={PromoChat}
         campaignsData={addedReceiptIdsCampaignData}
         handleRepeatButtonClick={handleRepeatButtonOnClick}
         handleSettingsSaveButtonClick={handleSettingsSaveButtonOnClick}
@@ -207,6 +212,7 @@ describe('PromoDashboard', () => {
 
     render(
       <PromoDashboard
+        PromoChat={PromoChat}
         campaignsData={campaignStubData}
         handleSettingsSaveButtonClick={handleSettingsSaveButtonOnClick}
         handleCampaignClick={handleCampaignClick}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1566,6 +1566,11 @@
     "@testing-library/dom" "^8.5.0"
     "@types/react-dom" "^18.0.0"
 
+"@tincre/promo-chat@^0.0.15":
+  version "0.0.15"
+  resolved "https://registry.yarnpkg.com/@tincre/promo-chat/-/promo-chat-0.0.15.tgz#952977f911810cb747675814f79185d433b7bfce"
+  integrity sha512-Xc+FOKxS4xv1fjWSMMp5FHT1wd+J7O9HuvjzH3SUI9wMmU3BjIDXx3a5GaeVT8aBMtc9lXlNytr1cl5pALwnHA==
+
 "@tincre/promo-types@^0.0.2":
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/@tincre/promo-types/-/promo-types-0.0.2.tgz#e4ae7dd425ba00eca432f4fc8091cbf90f1126ff"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1566,11 +1566,6 @@
     "@testing-library/dom" "^8.5.0"
     "@types/react-dom" "^18.0.0"
 
-"@tincre/promo-chat@^0.0.12":
-  version "0.0.12"
-  resolved "https://registry.yarnpkg.com/@tincre/promo-chat/-/promo-chat-0.0.12.tgz#9e38fd7ea33e0db6be67d8b7783a6ff7ea4a578c"
-  integrity sha512-3ZCLSDKu1z7UzDtLI3q3UT3YBCfuBccT3sARwlCUTn6cJGmSE402DLK4Zj6yBWZugHPJdRp0pGSvXteHfA0CLQ==
-
 "@tincre/promo-types@^0.0.2":
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/@tincre/promo-types/-/promo-types-0.0.2.tgz#e4ae7dd425ba00eca432f4fc8091cbf90f1126ff"


### PR DESCRIPTION
This merge removes the explicit [Promo Chat](https://github.com/Tincre/promo-chat) dependency and instead moves that to a required prop. 

Users can import it as also noted in the documentation:

```jsx 
import { PromoChat } from '@tincre/promo-chat'

<PromoDashboard PromoChat={PromoChat} />
```

In addition, this merge completely moves the `PromoChat` render to outside of the dashboard container (an internal component) to fix styling bugs caused by that previous placement. 