### PR TITLE
Feature/make campaigns data optional

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -32,7 +32,7 @@ import { DownloadAllCampaignsButton } from './components/DownloadButton';
 import { tourSteps } from './lib/tourSteps';
 
 export function PromoDashboard({
-  campaignsData = [],
+  campaignsData,
   campaignDetailData,
   profileSettingsData,
   isLoading,
@@ -45,7 +45,7 @@ export function PromoDashboard({
   PromoChat,
   dashboardOptions,
 }: {
-  campaignsData: CampaignData[] | CampaignDummyData[];
+  campaignsData?: CampaignData[] | CampaignDummyData[];
   campaignDetailData?: CampaignData | CampaignDummyData;
   profileSettingsData?: Settings;
   isLoading?: boolean;

--- a/src/lib/hooks/usePromoDashboardData.tsx
+++ b/src/lib/hooks/usePromoDashboardData.tsx
@@ -25,8 +25,8 @@ const METRICS: CampaignMetrics[] = [
  * @description A React hook that returns the sorted dashboard data and number of active campaigns.
  */
 export function usePromoDashboardData(
-  campaignsData: CampaignData[] | CampaignDummyData[],
-  deletedCampaigns: string[]
+  campaignsData?: CampaignData[] | CampaignDummyData[],
+  deletedCampaigns?: string[]
 ) {
   const [numberOfActiveCampaigns, setNumberOfActiveCampaigns] = useState<
     number | undefined


### PR DESCRIPTION
This merge makes the `campaignsData` input property on the `PromoDashboard` component optional. This sets up further work down the road to add a basic no-campaign screen that provides further motivation to run a campaign, when no data are present.