### PR TITLE
Feature/add promo type button ids and default dark styling

### DIFF
--- a/src/components/NoData.tsx
+++ b/src/components/NoData.tsx
@@ -126,10 +126,10 @@ export function NoData({
 }) {
   return (
     <>
-      <h3 className="leading-5 text-base font-bold text-slate-900">
+      <h3 className="leading-5 text-base font-bold text-slate-900 dark:text-slate-100">
         Create a campaign
       </h3>
-      <p className="pb-6">{`Press a campaign type to start the easiest ad campaign you've ever run.`}</p>
+      <p className="pb-6 dark:text-slate-300">{`Press a campaign type to start the easiest ad campaign you've ever run.`}</p>
       <div className="border-t border-gray-200 pb-6 pt-6">
         <ul
           role="list"

--- a/src/components/NoData.tsx
+++ b/src/components/NoData.tsx
@@ -80,12 +80,12 @@ export function CampaignType({
     : `flex h-16 w-16 flex-shrink-0 items-center justify-center rounded-lg bg-indigo-500`;
   const Icon = iconMap.get(icon || 'megaphone') || MegaphoneIcon;
   return (
-    <div className="relative -m-2 flex items-center space-x-4 rounded-xl p-2 focus-within:ring-2 focus-within:ring-indigo-500 hover:bg-slate-100 hover:scale-105 transition ease-in-out duration-300">
+    <div className="relative -m-2 flex items-center space-x-4 rounded-xl p-2 focus-within:ring-2 focus-within:ring-indigo-500 hover:bg-slate-100 hover:scale-105 transition ease-in-out duration-300 dark:hover:bg-slate-700 group">
       <div className={iconClassName}>
         <Icon className="h-6 w-6 text-white" aria-hidden="true" />
       </div>
       <div>
-        <h4 className="text-sm font-medium text-slate-900 cursor-pointer">
+        <h4 className="text-sm font-medium text-slate-900 cursor-pointer dark:text-slate-200 dark:group-hover:text-slate-100">
           <button
             onClick={(event) =>
               handleCampaignTypeButtonClick !== undefined
@@ -102,7 +102,7 @@ export function CampaignType({
             <Arrow />
           </button>
         </h4>
-        <p className="mt-1 text-sm text-slate-600 cursor-pointer">
+        <p className="mt-1 text-sm text-slate-600 cursor-pointer dark:text-slate-400 dark:group-hover:text-slate-200">
           {description}
         </p>
       </div>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -94,7 +94,7 @@ export function PromoDashboard({
   const [statsHighlightTimeseries, setStatsHighlightTimeseries] = useState<
     CampaignStatsData | undefined
   >(undefined);
-  const [defaultCampaignTypeContent, setDefaultCampaignTypeContent] = useState<
+  const [defaultCampaignTypeContent] = useState<
     { name: string; description?: string; icon?: string; color?: string }[]
   >([...options.campaignTypes, ...(dashboardOptions?.campaignTypes || [])]);
   const [clickedStatsClassName, setClickedStatsClassName] = useState<string>(


### PR DESCRIPTION
This adds dark mode styling for the initial load of the dashboard for undefined `campaignsData` values.