### PR TITLE
:bug: fix cost-metric coloring to take reversed values

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,11 +53,11 @@
   "size-limit": [
     {
       "path": "dist/promo-dashboard.cjs.production.min.js",
-      "limit": "20 KB"
+      "limit": "25 KB"
     },
     {
       "path": "dist/promo-dashboard.esm.js",
-      "limit": "20 KB"
+      "limit": "25 KB"
     }
   ],
   "devDependencies": {

--- a/src/components/CampaignsStatsHighlights.tsx
+++ b/src/components/CampaignsStatsHighlights.tsx
@@ -7,6 +7,8 @@
 import { ArrowDownIcon, ArrowUpIcon } from '@heroicons/react/20/solid';
 import { CampaignStatsData } from '@tincre/promo-types';
 import { YouTubeIcon } from './YouTubeIcon';
+
+const costBasedMetrics = ['CPM', 'CPC', 'CPV'];
 /* @ts-ignore */
 function classNames(...classes) {
   return classes.filter(Boolean).join(' ');
@@ -83,15 +85,29 @@ export function CampaignsStatsHighlights({
                   )}
                 >
                   {item.changeType === 'increase' ? (
-                    <ArrowUpIcon
-                      className="h-3 w-3 flex-shrink-0 self-center text-green-600 dark:text-green-400"
-                      aria-hidden="true"
-                    />
+                    !costBasedMetrics.includes(item.name) ? (
+                      <ArrowUpIcon
+                        className="h-5 w-5 flex-shrink-0 self-center text-green-600 dark:text-green-400"
+                        aria-hidden="true"
+                      />
+                    ) : (
+                      <ArrowDownIcon
+                        className="h-5 w-5 flex-shrink-0 self-center text-green-600 dark:text-green-400"
+                        aria-hidden="true"
+                      />
+                    )
                   ) : item.changeType !== 'same' ? (
-                    <ArrowDownIcon
-                      className="h-3 w-3 flex-shrink-0 self-center text-red-600 dark:text-red-400"
-                      aria-hidden="true"
-                    />
+                    !costBasedMetrics.includes(item.name) ? (
+                      <ArrowDownIcon
+                        className="h-5 w-5 flex-shrink-0 self-center text-red-600 dark:text-red-400"
+                        aria-hidden="true"
+                      />
+                    ) : (
+                      <ArrowUpIcon
+                        className="h-5 w-5 flex-shrink-0 self-center text-red-600 dark:text-red-400"
+                        aria-hidden="true"
+                      />
+                    )
                   ) : null}
 
                   <span className="sr-only">

--- a/src/components/StatsHighlights.tsx
+++ b/src/components/StatsHighlights.tsx
@@ -80,15 +80,29 @@ export function StatsHighlights({
                   )}
                 >
                   {item.changeType === 'increase' ? (
-                    <ArrowUpIcon
-                      className="h-5 w-5 flex-shrink-0 self-center text-green-600 dark:text-green-400"
-                      aria-hidden="true"
-                    />
+                    !['CPM', 'CPC', 'CPV'].includes(item.name) ? (
+                      <ArrowUpIcon
+                        className="h-5 w-5 flex-shrink-0 self-center text-green-600 dark:text-green-400"
+                        aria-hidden="true"
+                      />
+                    ) : (
+                      <ArrowDownIcon
+                        className="h-5 w-5 flex-shrink-0 self-center text-green-600 dark:text-green-400"
+                        aria-hidden="true"
+                      />
+                    )
                   ) : item.changeType !== 'same' ? (
-                    <ArrowDownIcon
-                      className="h-5 w-5 flex-shrink-0 self-center text-red-600 dark:text-red-400"
-                      aria-hidden="true"
-                    />
+                    !['CPM', 'CPC', 'CPV'].includes(item.name) ? (
+                      <ArrowDownIcon
+                        className="h-5 w-5 flex-shrink-0 self-center text-red-600 dark:text-red-400"
+                        aria-hidden="true"
+                      />
+                    ) : (
+                      <ArrowUpIcon
+                        className="h-5 w-5 flex-shrink-0 self-center text-red-600 dark:text-red-400"
+                        aria-hidden="true"
+                      />
+                    )
                   ) : null}
 
                   <span className="sr-only">

--- a/src/components/StatsHighlights.tsx
+++ b/src/components/StatsHighlights.tsx
@@ -7,6 +7,8 @@
 import { CampaignStatsData } from '@tincre/promo-types';
 import { ArrowDownIcon, ArrowUpIcon } from '@heroicons/react/20/solid';
 import { YouTubeIcon } from './YouTubeIcon';
+
+const costBasedMetrics = ['CPM', 'CPC', 'CPV'];
 /* @ts-ignore */
 function classNames(...classes) {
   return classes.filter(Boolean).join(' ');
@@ -80,7 +82,7 @@ export function StatsHighlights({
                   )}
                 >
                   {item.changeType === 'increase' ? (
-                    !['CPM', 'CPC', 'CPV'].includes(item.name) ? (
+                    !costBasedMetrics.includes(item.name) ? (
                       <ArrowUpIcon
                         className="h-5 w-5 flex-shrink-0 self-center text-green-600 dark:text-green-400"
                         aria-hidden="true"
@@ -92,7 +94,7 @@ export function StatsHighlights({
                       />
                     )
                   ) : item.changeType !== 'same' ? (
-                    !['CPM', 'CPC', 'CPV'].includes(item.name) ? (
+                    !costBasedMetrics.includes(item.name) ? (
                       <ArrowDownIcon
                         className="h-5 w-5 flex-shrink-0 self-center text-red-600 dark:text-red-400"
                         aria-hidden="true"

--- a/src/lib/coerce.ts
+++ b/src/lib/coerce.ts
@@ -91,9 +91,15 @@ export function computeChange(data: (string | number | null)[]) {
   }
   return 0;
 }
-export function computeChangeType(changeAmount: number) {
+export function computeChangeType(
+  changeAmount: number,
+  isOpposite: boolean = false
+) {
   if (changeAmount !== 0) {
-    return changeAmount < 0 ? 'decrease' : 'increase';
+    if (!isOpposite) {
+      return changeAmount < 0 ? 'decrease' : 'increase';
+    }
+    return changeAmount < 0 ? 'increase' : 'decrease';
   }
   return 'same';
 }
@@ -183,7 +189,7 @@ export function prepareChartData(chartJsData: {
       stat: cpmStat,
       icon: EnvelopeOpenIcon,
       change: computeChange(chartJsData.cpm).toFixed(2),
-      changeType: computeChangeType(computeChange(chartJsData.cpm)),
+      changeType: computeChangeType(computeChange(chartJsData.cpm), true),
       chartData: {
         labels: chartJsData.updatedTime,
         data: chartJsData.cpm,
@@ -207,7 +213,7 @@ export function prepareChartData(chartJsData: {
       stat: cpcStat,
       icon: CursorArrowRaysIcon,
       change: computeChange(chartJsData.cpc).toFixed(2),
-      changeType: computeChangeType(computeChange(chartJsData.cpc)),
+      changeType: computeChangeType(computeChange(chartJsData.cpc), true),
       chartData: {
         labels: chartJsData.updatedTime,
         data: chartJsData.cpc,
@@ -219,7 +225,7 @@ export function prepareChartData(chartJsData: {
       stat: cpvStat,
       icon: VideoCameraIcon,
       change: computeChange(chartJsData.cpv).toFixed(2),
-      changeType: computeChangeType(computeChange(chartJsData.cpv)),
+      changeType: computeChangeType(computeChange(chartJsData.cpv), true),
       chartData: {
         labels: chartJsData.updatedTime,
         data: chartJsData.cpv,
@@ -354,7 +360,10 @@ export function aggregateChartData(
       maximumFractionDigits: 2,
       minimumFractionDigits: 0,
     }),
-    changeType: computeChangeType(change),
+    changeType: computeChangeType(
+      change,
+      ['CPC', 'CPV', 'CPM'].includes(localMetric)
+    ),
     chartData: { ...aggregateChartData },
   };
 }


### PR DESCRIPTION
This corresponds to https://app.asana.com/0/1206585806512386/1206591736793807/f and reverses the metric coloring for CPC, CPM, and CPV metrics within the dashboard.